### PR TITLE
[Fixed] navlink `docs` url typo

### DIFF
--- a/inert.config.js
+++ b/inert.config.js
@@ -17,7 +17,7 @@ const config = {
     description: `Promise based HTTP client for the browser and node.js`,
     navLinks: [
         {
-            href: '/docs',
+            href: '/docs/intro',
             text: 'Docs'
         },
         {


### PR DESCRIPTION
## issue
On left navigation link list: [`Docs`](https://axios-http.com/docs) lead to 404:
<img width="379" alt="Screen Shot 2021-04-05 at 14 55 39" src="https://user-images.githubusercontent.com/13027142/113551537-03647580-961f-11eb-94cc-756ddf298cc6.png">

There is no such URL:
<img width="810" alt="Screen Shot 2021-04-05 at 14 49 48" src="https://user-images.githubusercontent.com/13027142/113551476-e9c32e00-961e-11eb-90ef-acfa5c86c467.png">

## Changes
URL fixed to docs homepage, which should now translates to: `https://axios-http.com/docs/intro/`. I assume that is the correct URL, CMIIW.

Note: sorry about end-of-line newline changes, it somehow got added by Github