### PR TITLE
Fix emoji in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: '🐞 Bug report'
 about: Create a report to help us improve
 title: ''
-labels: ''
+labels: 'bug'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,5 +1,5 @@
 ---
-name: '\U0001F41E Bug report'
+name: '🐞 Bug report'
 about: Create a report to help us improve
 title: ''
 labels: ''

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: '✨ Feature request'
 about: Suggest an idea for this project
 title: ''
-labels: ''
+labels: 'enhancement'
 assignees: ''
 
 ---


### PR DESCRIPTION
For some reason, the bug report template was showing an escape sequence instead of a bug emoji. This PR fixes that.

@jasonsaayman