### PR TITLE
[Fixed] request config German translation

### DIFF
--- a/posts/de/req_config.md
+++ b/posts/de/req_config.md
@@ -6,22 +6,22 @@ next_title: 'Antwortenschema'
 next_link: '/docs/de/res_schema'
 ---
 
-Dies sind die verfügbaren Konfigurationsoptionen für HTTP-Anfragen. Nur das feld `url` wird benötigt. Anfragen weden standardmäßig die `GET`-Methode verwenden wenn die option `method` ausgelassen wird.
+Dies sind die verfügbaren Konfigurationsoptionen für HTTP-Anfragen. Nur das feld `url` wird benötigt. Für Anfragen wird standardmäßig die `GET`-Methode verwendet sofern die HTTP-Methode nicht explizit mit der Option `method` spezifiziert wird.
 
 ```js
 {
-  // `url` ist die Server-URL Die für die anfrage verwendet wird.
+  // `url` ist die Server-URL, die für die Anfrage verwendet wird.
   url: '/user',
 
   // `method` ist die zu verwendende HTTP-Methode
   method: 'get', // Standardwert
 
-  // `baseURL` wird and `url` vorangestellt wenn `url` nicht absolut ist.
+  // `baseURL` wird `url` vorangestellt außer bei `url` handelt es sich um eine absolute URL.
   // Dies ist speziell bei Axios-Instanzen nützlich wenn alle Anfragen der
   // Instanz an die selbe Domäne geschickt werden sollen.
   baseURL: 'https://some-domain.com/api/',
 
-  // `transformRequest` erlaubt Anderungen an den Anfragendaten bevor sie zum
+  // `transformRequest` erlaubt Änderungen an den Anfragendaten bevor sie zum
   // Server geschickt werden. Dies funktioniert nur bei den Methoden 'PUT',
   // 'POST', 'PATCH' und 'DELETE'. Die letzte Funktion in der liste muss einen
   // String,  Buffer, ArrayBuffer, FormData oder Stream zurückgeben.
@@ -32,7 +32,7 @@ Dies sind die verfügbaren Konfigurationsoptionen für HTTP-Anfragen. Nur das fe
     return data;
   }],
 
-  // `transformResponse` erlaubt Anderungen an den Zurückgegebenen daten bevor
+  // `transformResponse` erlaubt Änderungen an denzZurückgegebenen Daten bevor
   // diese an `then` bzw. `catch` weitergeben werden.
   transformResponse: [function (data) {
     // Tun sie was auch immer sie wollen um die daten zu transformieren
@@ -43,23 +43,23 @@ Dies sind die verfügbaren Konfigurationsoptionen für HTTP-Anfragen. Nur das fe
   // Eigene Headers
   headers: {'X-Requested-With': 'XMLHttpRequest'},
 
-  // `params` sind die URL-Parameter die in der Anfrage geschickt weden. Das feld
+  // `params` sind die URL-Parameter, die in der Anfrage geschickt werden. Das Feld
   // muss entweder ein einfaches Object oder eine Instanz der Klasse URLSearchParams
   // beinhalten.
   params: {
     ID: 12345
   },
 
-  // Mit `paramsSerializer` kann optioanl die Funktion zur serialisation des
-  // feldes `params` manuell überschrieben werden.
-  // (e.g. https://www.npmjs.com/package/qs, http://api.jquery.com/jquery.param/)
+  // Mit `paramsSerializer` kann optional die Funktion zur Serialisierung des
+  // Feldes `params` manuell überschrieben werden.
+  // (z.Bsp. https://www.npmjs.com/package/qs, http://api.jquery.com/jquery.param/)
   paramsSerializer: function (params) {
     return Qs.stringify(params, {arrayFormat: 'brackets'})
   },
 
-  // `data` sind die Daten die im Körper der Anfrage geschickt werden sollen.
-  // Funktioniert nur bei 'PUT', 'POST', 'DELETE' und 'PATCH'
-  // Wenn transformRequest nicht gesetzt ist muss das feld einen folgender datentypen besitzen:
+  // `data` beinhaltet die Daten, die im Körper der Anfrage übertragen werden sollen.
+  // `data` wird nur bei den HTTP-Methoden 'PUT', 'POST', 'DELETE' und 'PATCH' berücksichtigt.
+  // Wenn `transformRequest` nicht gesetzt ist, muss das Feld einer der folgenden Datentypen sein:
   //  - String, einfaches Objekt, ArrayBuffer, ArrayBufferView, URLSearchParams
   //  - Im Browser auch: FormData, File, Blob
   //  - In Node.js auch: Stream, Buffer
@@ -73,11 +73,11 @@ Dies sind die verfügbaren Konfigurationsoptionen für HTTP-Anfragen. Nur das fe
   // Maximale Anzahl an Millisekunden bevor die Anfrage abgebrochen wird
   timeout: 1000, // Standardwert: `0` (kein timeout)
 
-  // `withCredentials` Gibt an ob Cross-Site-Access-Control-Anfragen mit Credentials
+  // `withCredentials` gibt an, ob Cross-Site-Access-Control-Anfragen mit Credentials
   // ausgeführt werden sollen
   withCredentials: false, // Standardwert
 
-  // `adapter` erlaubt einfacheres testen, siehe https://github.com/axios/axios/blob/master/lib/adapters/README.md
+  // `adapter` erlaubt ein einfacheres Testen, siehe https://github.com/axios/axios/blob/master/lib/adapters/README.md
   adapter: function (config) {
     /* ... */
   },
@@ -88,12 +88,12 @@ Dies sind die verfügbaren Konfigurationsoptionen für HTTP-Anfragen. Nur das fe
     password: 's00pers3cret'
   },
 
-  // `responseType` Gibt den datentypen der Serverantwort an.
-  // Optionen sind: 'arraybuffer', 'document', 'json', 'text', 'stream'
+  // `responseType` Gibt den Datentypen der Serverantwort an.
+  // Mögliche Werte sind: 'arraybuffer', 'document', 'json', 'text', 'stream'
   // (Nur im Browser auch 'blob')
   responseType: 'json', // Standardwert
 
-  // `responseEncoding` (Nur in nodejs) gibt das Encoding das zur Dekodierung der Antwort verwendet werden soll
+  // `responseEncoding` (Nur in nodejs) gibt das Encoding das zur Dekodierung der Antwort verwendet werden soll an
   responseEncoding: 'utf8', // Standartwert
 
   // `xsrfCookieName` Name des Cookies zur nutzung für XSRF-tokens
@@ -102,14 +102,14 @@ Dies sind die verfügbaren Konfigurationsoptionen für HTTP-Anfragen. Nur das fe
   // `xsrfHeaderName` Name des Headers der das XSRF-token trägt
   xsrfHeaderName: 'X-XSRF-TOKEN', // Standardwert
 
-  // `onUploadProgress` erlaubt die Behandlung von Progress-Events im browser
-  // Nur im browser
+  // `onUploadProgress` erlaubt die Behandlung von Progress-Events im Browser
+  // Nur im Browser
   onUploadProgress: function (progressEvent) {
     // Progress-Event Verarbeiten
   },
 
-  // `onDownloadProgress` erlaubt die Behandlung von Progress-Events im browser
-  // Nur im browser
+  // `onDownloadProgress` erlaubt die Behandlung von Progress-Events im Browser
+  // Nur im Browser
   onDownloadProgress: function (progressEvent) {
     /// Progress-Event Verarbeiten
   },
@@ -120,26 +120,26 @@ Dies sind die verfügbaren Konfigurationsoptionen für HTTP-Anfragen. Nur das fe
   // `maxBodyLength` definiert die maximale Größe des Anfragenkörpers (nur in Nodejs)
   maxBodyLength: 2000,
 
-  // `validateStatus` Gibt basiert auf den status-code an ob die anfrage erflogreich war
+  // `validateStatus` Gibt, basierend auf dem Status-Code an, ob die Anfrage erfolgreich war.
   validateStatus: function (status) {
     return status >= 200 && status < 300; // Standardwert
   },
 
-  // Maximale menge an redirects denen gefolgt wird
+  // Maximale Menge an Redirects denen gefolgt wird
   maxRedirects: 5, // default
 
-  // Pfad zu einer UNIX-Socker die in Nodejs verwendet werden soll
+  // Pfad zu einem UNIX-Socket, der in Nodejs verwendet werden soll
   socketPath: null, // default
 
-  // Eigene agenten zur verarbeitung von http und https. Nur in nodejs
+  // Eigene Agenten zur Verarbeitung von http und https. Nur in nodejs
   httpAgent: new http.Agent({ keepAlive: true }),
   httpsAgent: new https.Agent({ keepAlive: true }),
 
   // `proxy` definiert Hostname, Port, und Protokoll des Proxy-Servers.
-  // Ein Proxy kann auch durch die Verwendung der Umgebungsvariablen
-  // http_proxy und https_proxy Konfiguriert werden falls sie Umgebungsvariablen
-  // verwenden. `auth` gibt die HTTP basic auth credentials des Proxy-Servers an.
-  // Dies wird den `Proxy-Authorization` header überschreiben.
+  // Ein Proxy kann auch durch das Setzen der Umgebungsvariablen
+  // http_proxy und https_proxy konfiguriert werden.
+  // `auth` gibt die HTTP basic auth credentials des Proxy-Servers an.
+  // Dies wird den `Proxy-Authorization` Header geschrieben.
   proxy: {
     protocol: 'https',
     host: '127.0.0.1',


### PR DESCRIPTION
Some typos and tricky German capitalisations.

I also took the freedom to rephrase some sentences with the aim to solely make them read better in German. The sentences were perfectly understandable before already. If you have feedback, please let me know.