### PR TITLE
Added note about params with null value.

### DIFF
--- a/posts/en/req_config.md
+++ b/posts/en/req_config.md
@@ -46,6 +46,7 @@ These are the available config options for making requests. Only the `url` is re
 
   // `params` are the URL parameters to be sent with the request
   // Must be a plain object or a URLSearchParams object
+  // NOTE: params that are null or undefined are not rendered in the URL.
   params: {
     ID: 12345
   },


### PR DESCRIPTION
I never remember how the query params are rendered when building the URL when the params contains null or undefined. :)

The current version doesn't render the params (which seems to be the correct behavior).