### PR TITLE
A warning for statusText in HTTP/2

### DIFF
--- a/posts/en/res_schema.md
+++ b/posts/en/res_schema.md
@@ -17,6 +17,7 @@ The response for a request contains the following information.
   status: 200,
 
   // `statusText` is the HTTP status message from the server response
+  // Watch out in HTTP/2, statusText: ''
   statusText: 'OK',
 
   // `headers` the HTTP headers that the server responded with


### PR DESCRIPTION
In HTTP/2 (https://www.rfc-editor.org/rfc/rfc7540#section-8.1.2.4) statusText no longer exists so one gets an empty string.