### PR TITLE
[Fixed] Revert "fix: typo (#71)"

### DIFF
--- a/posts/en/interceptors.md
+++ b/posts/en/interceptors.md
@@ -34,7 +34,7 @@ If you need to remove an interceptor later you can.
 
 ```js
 const myInterceptor = axios.interceptors.request.use(function () {/*...*/});
-axios.interceptors.request.reject(myInterceptor);
+axios.interceptors.request.eject(myInterceptor);
 ```
 
 You can add interceptors to a custom instance of axios.


### PR DESCRIPTION
Reverts #71.

It looks like there was some confusion between `Promise.reject()` and `InterceptorManager.eject()` here. This wasn't a typo.