### PR TITLE
[Added] add Japanese translation (locale: ja)

### DIFF
--- a/inert.config.js
+++ b/inert.config.js
@@ -27,6 +27,7 @@ const krConfig = require("./kr.lang.js");
 const viConfig = require("./vi.lang.js");
 const faConfig = require("./fa.lang.js");
 const ruConfig = require("./ru.lang.js");
+const jaConfig = require("./ja.lang.js");
 
 // List of languages
 const langs = [
@@ -108,6 +109,12 @@ const langs = [
     name: "Русский",
     prefix: "/ru/",
     config: ruConfig
+  },
+  {
+    dir: "ltr",
+    name: "日本語",
+    prefix: "/ja/",
+    config: jaConfig
   }
 ];
 

--- a/ja.lang.js
+++ b/ja.lang.js
@@ -1,0 +1,142 @@
+/**
+ * Configuration for the Japanese (ja) translation
+ */
+
+module.exports = {
+  // Language display name. MUST BE THE SAME AS IN [inert.config.js].custom.langs
+  display: "日本語",
+  prefix: "/ja/",
+  dir: "ltr",
+  lang: "ja",
+  // `p` stands for `paragraph`. This will contain translations of full text blocks
+  p: {
+    headline: "ブラウザと Node.js のための Promise ベースの HTTP クライアント",
+    subhead: `Axios は、ブラウザと Node.js のための、シンプルなプロミスベースの HTTP クライアントです。
+              Axios は、非常に拡張性の高いインターフェイスを持つ小さなパッケージで、
+              シンプルに使えるライブラリを提供します。`,
+  },
+  // `t` stands fot `translation`. This will contain translations of single words or phrases
+  t: {
+    "Get Started": 'Axios 入門',
+    "View on GitHub": 'GitHub で表示',
+    "Languages": '言語',
+    "Open Source": 'オープンソース',
+    "Contribute": 'コントリビュート (貢献)',
+    "Source on GitHub": 'GitHub 上のソース',
+    "Issues": 'イシュー',
+    "Pull Requests": 'プルリクエスト',
+    "Code of Conduct": '行動規範',
+    "Fork on GitHub": 'GitHub でのフォーク',
+    "Fork the Website": 'Web サイトをフォークする',
+    "Create an Issue": 'イシューを作成する',
+    "Next": '次へ',
+    "Previous": '前へ',
+    "Website Copy Right Footer": 'Web サイトの著作権フッター',
+    "View On Github": 'GitHub で表示',
+    "Axios Project Copy Right Footer": 'Axios プロジェクトの著作権フッター',
+    "License Label Footer": 'ライセンスラベル フッター'
+  },
+  sidebar: [
+    {
+      type: "heading",
+      text: "Axiom 入門",
+    },
+    {
+      type: "link",
+      href: "/docs/intro",
+      text: "Axiom 入門",
+    },
+    {
+      type: "link",
+      href: "/docs/example",
+      text: "使用例",
+    },
+    {
+      type: "link",
+      href: "/docs/post_example",
+      text: "POST リクエスト",
+    },
+    {
+      type: "heading",
+      text: "Axios API",
+    },
+    {
+      type: "link",
+      href: "/docs/api_intro",
+      text: "Axios API",
+    },
+    {
+      type: "link",
+      href: "/docs/instance",
+      text: "Axios インスタンス",
+    },
+    {
+      type: "link",
+      href: "/docs/req_config",
+      text: "リクエスト設定",
+    },
+    {
+      type: "link",
+      href: "/docs/res_schema",
+      text: "レスポンス スキーマ",
+    },
+    {
+      type: "link",
+      href: "/docs/config_defaults",
+      text: "デフォルト設定",
+    },
+    {
+      type: "link",
+      href: "/docs/interceptors",
+      text: "インターセプター",
+    },
+    {
+      type: "link",
+      href: "/docs/handling_errors",
+      text: "エラー処理",
+    },
+    {
+      type: "link",
+      href: "/docs/cancellation",
+      text: "キャンセル",
+    },
+    {
+      type: "link",
+      href: "/docs/urlencoded",
+      text: "URL-エンコードボディ",
+    },
+    {
+      type: "heading",
+      text: "その他",
+    },
+    {
+      type: "link",
+      href: "/docs/notes",
+      text: "特記事項",
+    },
+    {
+      type: "heading",
+      text: "コントリビューター",
+    },
+    {
+      type: "link",
+      href: "https://github.com/axios/axios/blob/master/CODE_OF_CONDUCT.md",
+      text: "行動規範",
+    },
+    {
+      type: "link",
+      href: "https://github.com/axios/axios/blob/master/COLLABORATOR_GUIDE.md",
+      text: "コントリビューター ガイド",
+    },
+    {
+      type: "link",
+      href: "https://github.com/axios/axios/blob/master/CONTRIBUTING.md",
+      text: "Axios に貢献する"
+    },
+    {
+      type: "link",
+      href: "/docs/translating",
+      text: "このドキュメントを翻訳する"
+    }
+  ],
+};

--- a/posts/ja/api_intro.md
+++ b/posts/ja/api_intro.md
@@ -1,0 +1,60 @@
+---
+title: 'Axios API'
+description: 'Axios API リファレンス'
+prev_title: 'POST リクエスト'
+prev_link: '/docs/post_example'
+next_title: 'Axios インスタンス'
+next_link: '/docs/instance'
+---
+
+関連する設定を `axios` に渡すことでリクエストを行うことができます。
+
+##### axios(config)
+
+```js
+// POST リクエストを送信する
+axios({
+  method: 'post',
+  url: '/user/12345',
+  data: {
+    firstName: 'Fred',
+    lastName: 'Flintstone'
+  }
+});
+```
+
+```js
+// Node.js でのリモート画像を GET リクエスト
+axios({
+  method: 'get',
+  url: 'http://bit.ly/2mTM3nY',
+  responseType: 'stream'
+})
+  .then(function (response) {
+    response.data.pipe(fs.createWriteStream('ada_lovelace.jpg'))
+  });
+```
+
+##### axios(url[, config])
+
+```js
+// GET リクエストの送信（デフォルト メソッド）
+axios('/user/12345');
+```
+
+### リクエスト メソッドのエイリアス
+
+使いやすいように、サポートされているすべてのリクエスト メソッドにエイリアスが提供されています。
+
+##### axios.request(config)
+##### axios.get(url[, config])
+##### axios.delete(url[, config])
+##### axios.head(url[, config])
+##### axios.options(url[, config])
+##### axios.post(url[, data[, config]])
+##### axios.put(url[, data[, config]])
+##### axios.patch(url[, data[, config]])
+
+###### 注
+
+エイリアス メソッドを使用する場合、`url`、` method`、および `data` プロパティを設定で指定する必要はありません。

--- a/posts/ja/cancellation.md
+++ b/posts/ja/cancellation.md
@@ -1,0 +1,107 @@
+---
+title: 'Cancellation'
+prev_title: 'Handling Errors'
+prev_link: '/docs/handling_errors'
+next_title: 'URL-Encoding Bodies'
+next_link: '/docs/urlencoded'
+---
+
+## AbortController
+
+Starting from `v0.22.0` Axios supports [`AbortController`](https://developer.mozilla.org/en-US/docs/Web/API/AbortController) to cancel requests in fetch API way:
+
+```js
+const controller = new AbortController();
+
+axios.get('/foo/bar', {
+   signal: controller.signal
+}).then(function(response) {
+   //...
+});
+// cancel the request
+controller.abort()
+```
+
+## CancelToken `deprecated`
+
+You can also cancel a request using a *CancelToken*. 
+
+> The axios cancel token API is based on the withdrawn [cancelable promises proposal](https://github.com/tc39/proposal-cancelable-promises).
+
+> This API is deprecated since `v0.22.0` and shouldn't be used in new projects
+
+You can create a cancel token using the `CancelToken.source` factory as shown below:
+
+```js
+const CancelToken = axios.CancelToken;
+const source = CancelToken.source();
+
+axios.get('/user/12345', {
+  cancelToken: source.token
+}).catch(function (thrown) {
+  if (axios.isCancel(thrown)) {
+    console.log('Request canceled', thrown.message);
+  } else {
+    // handle error
+  }
+});
+
+axios.post('/user/12345', {
+  name: 'new name'
+}, {
+  cancelToken: source.token
+})
+
+// cancel the request (the message parameter is optional)
+source.cancel('Operation canceled by the user.');
+```
+
+You can also create a cancel token by passing an executor function to the `CancelToken` constructor:
+
+```js
+const CancelToken = axios.CancelToken;
+let cancel;
+
+axios.get('/user/12345', {
+  cancelToken: new CancelToken(function executor(c) {
+    // An executor function receives a cancel function as a parameter
+    cancel = c;
+  })
+});
+
+// cancel the request
+cancel();
+```
+
+> Note: you can cancel several requests with the same cancel token / signal.
+
+During the transition period, you can use both cancellation APIs, even for the same request:
+
+```js
+const controller = new AbortController();
+
+const CancelToken = axios.CancelToken;
+const source = CancelToken.source();
+
+axios.get('/user/12345', {
+  cancelToken: source.token,
+  signal: controller.signal
+}).catch(function (thrown) {
+  if (axios.isCancel(thrown)) {
+    console.log('Request canceled', thrown.message);
+  } else {
+    // handle error
+  }
+});
+
+axios.post('/user/12345', {
+  name: 'new name'
+}, {
+  cancelToken: source.token
+})
+
+// cancel the request (the message parameter is optional)
+source.cancel('Operation canceled by the user.');
+// OR
+controller.abort(); // the message parameter is not supported
+```

--- a/posts/ja/config_defaults.md
+++ b/posts/ja/config_defaults.md
@@ -1,0 +1,50 @@
+---
+title: 'デフォルト設定'
+prev_title: 'レスポンス スキーマ'
+prev_link: '/docs/res_schema'
+next_title: 'インターセプター'
+next_link: '/docs/interceptors'
+---
+
+## デフォルト設定
+
+すべてのリクエストに適用されるデフォルト設定を指定できます。
+
+### グローバル Axios のデフォルト
+
+```js
+axios.defaults.baseURL = 'https://api.example.com';
+axios.defaults.headers.common['Authorization'] = AUTH_TOKEN;
+axios.defaults.headers.post['Content-Type'] = 'application/x-www-form-urlencoded';
+```
+
+### カスタム インスタンスのデフォルト
+
+```js
+// インスタンスの作成時にデフォルト設定を指定する
+const instance = axios.create({
+  baseURL: 'https://api.example.com'
+});
+
+// インスタンスの作成後にデフォルト設定を変更する
+instance.defaults.headers.common['Authorization'] = AUTH_TOKEN;
+```
+
+### 設定の優先順位
+
+設定は、優先順位をつけてマージされます。その順番は [lib/defaults.js](https://github.com/axios/axios/blob/master/lib/defaults.js#L28) にあるライブラリのデフォルト、そしてインスタンスの `defaults` プロパティ、最後にリクエストの `config` 引数の順になります。後者が前者よりも優先されます。以下はその例です。
+
+```js
+// ライブラリが提供するデフォルトの設定を使用してインスタンスを作成します。
+// この時点では、タイムアウトの設定値はライブラリのデフォルトである `0` になっています。
+const instance = axios.create();
+
+// ライブラリのデフォルトのタイムアウトを上書きします。
+// これで、このインスタンスを使用するすべてのリクエストは、タイムアウトする前に 2.5秒待機します。
+instance.defaults.timeout = 2500;
+
+// 時間がかかることがわかっているため、このリクエストのタイムアウトをオーバーライドします。
+instance.get('/longRequest', {
+  timeout: 5000
+});
+```

--- a/posts/ja/example.md
+++ b/posts/ja/example.md
@@ -1,0 +1,69 @@
+---
+title: '最小構成の使用例'
+description: 'Axios の簡単な使用例'
+prev_title: 'Axios 入門'
+prev_link: '/docs/intro'
+next_title: 'POST リクエスト'
+next_link: '/docs/post_example'
+---
+
+## 注: CommonJS の使用法
+
+CommonJS の `require()` 関数でインポートをしながら、TypeScript の型付け (インテリセンスやオートコンプリートのため) を利用するためには、以下の方法を使用します。
+
+```js
+const axios = require('axios').default;
+
+// axios.<method> がオートコンプリートやパラメータの型付けを提供するようになります
+```
+
+# 例
+
+`GET` リクエストを実行する
+
+```js
+const axios = require('axios');
+
+// 指定された ID のユーザーに対してリクエストを行う
+axios.get('/user?ID=12345')
+  .then(function (response) {
+    // 処理が成功した場合
+    console.log(response);
+  })
+  .catch(function (error) {
+    // エラー処理
+    console.log(error);
+  })
+  .then(function () {
+    // 常に実行
+  });
+
+// オプションとして、上記のリクエストは次のようにすることもできます
+axios.get('/user', {
+    params: {
+      ID: 12345
+    }
+  })
+  .then(function (response) {
+    console.log(response);
+  })
+  .catch(function (error) {
+    console.log(error);
+  })
+  .then(function () {
+    // 常に実行
+  });  
+
+// async/await を使いたい場合は、外側の関数/メソッドに `async` キーワードを追加してください。
+async function getUser() {
+  try {
+    const response = await axios.get('/user?ID=12345');
+    console.log(response);
+  } catch (error) {
+    console.error(error);
+  }
+}
+```
+
+> **注:** `async/await`は ECMAScript 2017 の一部であり、Internet Explorer および
+> 古いブラウザーではサポートされていないため、注意して使用してください。

--- a/posts/ja/handling_errors.md
+++ b/posts/ja/handling_errors.md
@@ -1,0 +1,47 @@
+---
+title: 'エラー処理'
+prev_title: 'インターセプター'
+prev_link: '/docs/interceptors'
+next_title: 'キャンセル'
+next_link: '/docs/cancellation'
+---
+
+```js
+axios.get('/user/12345')
+  .catch(function (error) {
+    if (error.response) {
+      // リクエストが行われ、サーバーは 2xx の範囲から外れるステータスコードで応答しました
+      console.log(error.response.data);
+      console.log(error.response.status);
+      console.log(error.response.headers);
+    } else if (error.request) {
+      // リクエストは行われましたが、応答がありませんでした
+      // `error.request` は、ブラウザでは XMLHttpRequest のインスタンスになり、
+      // Node.js では http.ClientRequest のインスタンスになります。
+      console.log(error.request);
+    } else {
+      // エラーをトリガーしたリクエストの設定中に何かが発生しました
+      console.log('Error', error.message);
+    }
+    console.log(error.config);
+  });
+```
+
+`ValidateStatus` 設定オプションを使用すると、エラーをスローする HTTP コードを定義できます。
+
+```js
+axios.get('/user/12345', {
+  validateStatus: function (status) {
+    return status < 500; // ステータスコードが 500 未満の場合にのみ解決します
+  }
+})
+```
+
+`toJSON` を使用すると、HTTP エラーに関する詳細情報を含むオブジェクトを取得できます。
+
+```js
+axios.get('/user/12345')
+  .catch(function (error) {
+    console.log(error.toJSON());
+  });
+```

--- a/posts/ja/instance.md
+++ b/posts/ja/instance.md
@@ -1,0 +1,35 @@
+---
+title: 'Axios インスタンス'
+prev_title: 'Axios API'
+prev_link: '/docs/api_intro'
+next_title: 'リクエスト設定'
+next_link: '/docs/req_config'
+---
+
+### インスタンスの作成
+
+カスタム設定で新しい Axios のインスタンスを作成できます。
+
+##### axios.create([config])
+
+```js
+const instance = axios.create({
+  baseURL: 'https://some-domain.com/api/',
+  timeout: 1000,
+  headers: {'X-Custom-Header': 'foobar'}
+});
+```
+
+### インスタンス メソッド
+
+利用可能なインスタンス メソッドを以下に示します。指定された設定は、インスタンス設定にマージされます。
+
+##### axios#request(config)
+##### axios#get(url[, config])
+##### axios#delete(url[, config])
+##### axios#head(url[, config])
+##### axios#options(url[, config])
+##### axios#post(url[, data[, config]])
+##### axios#put(url[, data[, config]])
+##### axios#patch(url[, data[, config]])
+##### axios#getUri([config])

--- a/posts/ja/interceptors.md
+++ b/posts/ja/interceptors.md
@@ -1,0 +1,45 @@
+---
+title: 'インターセプター'
+prev_title: 'デフォルト設定'
+prev_link: '/docs/config_defaults'
+next_title: 'エラー処理'
+next_link: '/docs/handling_errors'
+---
+
+リクエストやレスポンスが `then` や `catch` で処理される前に、それをインターセプトできます。
+
+```js
+// リクエスト インターセプターを追加します
+axios.interceptors.request.use(function (config) {
+    // リクエストが送信される前の処理
+    return config;
+  }, function (error) {
+    // リクエスト エラーの処理
+    return Promise.reject(error);
+  });
+
+// リクエスト インターセプターを追加します
+axios.interceptors.response.use(function (response) {
+    // ステータスコードが 2xx の範囲にある場合、この関数が起動します
+    // リクエスト データの処理
+    return response;
+  }, function (error) {
+    // ステータスコードが 2xx の範囲外の場合、この関数が起動します
+    // リクエスト エラーの処理
+    return Promise.reject(error);
+  });
+```
+
+後でインターセプターを削除する必要がある場合は、削除できます。
+
+```js
+const myInterceptor = axios.interceptors.request.use(function () {/*...*/});
+axios.interceptors.request.reject(myInterceptor);
+```
+
+axios のカスタム インスタンスにインターセプターを追加できます。
+
+```js
+const instance = axios.create();
+instance.interceptors.request.use(function () {/*...*/});
+```

--- a/posts/ja/intro.md
+++ b/posts/ja/intro.md
@@ -1,0 +1,54 @@
+---
+title: 'Axiom 入門'
+description: 'ブラウザと Node.js のための Promise ベースの HTTP クライアント'
+next_title: '最小構成の使用例'
+next_link: '/docs/example'
+---
+
+# Axios とは?
+
+Axios は、[`Node.js`]（https://nodejs.org/）とブラウザのための *[Promise ベース](https://javascript.info/promise-basics)* の HTTP クライアントです。 これは *[Isomorphic](https://www.lullabot.com/articles/what-is-an-isomorphic-application)*（= 同じコードベースでブラウザと Node.js の両方で実行できる）と呼ばれます。 サーバー側ではネイティブ の Node.js `http` モジュールを使用し、クライアント (ブラウザ) では XMLHttpRequests を使用します。
+
+
+# 特徴
+
+- ブラウザから [XMLHttpRequests](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest) を作成する
+- Node.js から [http](http://nodejs.org/api/http.html) リクエストを作成する
+- [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) API をサポート
+- インターセプトの要求と応答
+- リクエストとレスポンスのデータを変換
+- リクエストをキャンセル
+- JSON データの自動変換
+- [XSRF](http://en.wikipedia.org/wiki/Cross-site_request_forgery) から保護するためのクライアント側のサポート
+
+# インストール方法
+
+npm を利用する場合:
+
+```bash
+$ npm install axios
+```
+
+bower を利用する場合:
+
+```bash
+$ bower install axios
+```
+
+yarn を利用する場合:
+
+```bash
+$ yarn add axios
+```
+
+jsDelivr CDN を利用する場合:
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
+```
+
+unpkg CDN を利用する場合:
+
+```html
+<script src="https://unpkg.com/axios/dist/axios.min.js"></script>
+```

--- a/posts/ja/notes.md
+++ b/posts/ja/notes.md
@@ -1,0 +1,40 @@
+---
+title: '特記事項'
+description: '最後にもういくつかの注意点をあげておきます'
+prev_title: 'URL-エンコードボディ'
+prev_link: '/docs/urlencoded'
+---
+
+## Semver
+
+Axios が `1.0` のリリースに到達するまでは、新しいマイナーバージョンで破壊的な変更がリリースされます。例えば、`0.5.1` と `0.5.4` は同じ API ですが、`0.6.0` は破壊的な変更があります。
+
+## Promises
+
+Axios は、ネイティブの ES6 Promise の実装に依存し、[サポート](http://caniuse.com/promises) されています。
+ES6 Promise をサポートしていない環境では、[ポリフィル](https://github.com/jakearchibald/es6-promise) を利用できます。
+
+## TypeScript
+
+Axios には、[TypeScript](http://typescriptlang.org/) の定義が含まれています。
+
+```typescript
+import axios from 'axios';
+axios.get('/user?ID=12345');
+```
+
+## リソース
+
+* [変更履歴](https://github.com/axios/axios/blob/master/CHANGELOG.md)
+* [アップグレード ガイド](https://github.com/axios/axios/blob/master/UPGRADE_GUIDE.md)
+* [エコシステム](https://github.com/axios/axios/blob/master/ECOSYSTEM.md)
+* [コントリビューター ガイド](https://github.com/axios/axios/blob/master/CONTRIBUTING.md)
+* [行動規範](https://github.com/axios/axios/blob/master/CODE_OF_CONDUCT.md)
+
+## クレジット
+
+Axios は、[Angular](https://angularjs.org/) で提供される [$http サービス](https://docs.angularjs.org/api/ng/service/$http) に大きく影響を受けています。 最終的に Axios は、Angular の外で使えるスタンドアロンの `$http` のようなサービスを提供するための取り組みです。
+
+## ライセンス
+
+[MIT](https://github.com/axios/axios/blob/master/LICENSE)

--- a/posts/ja/post_example.md
+++ b/posts/ja/post_example.md
@@ -1,0 +1,41 @@
+---
+title: 'POST リクエスト'
+description: 'Axios で POST リクエストを実行する方法'
+prev_title: '最小構成の使用例'
+prev_link: '/docs/example'
+next_title: 'Axios API'
+next_link: '/docs/api_intro'
+---
+
+`POST` リクエストの実行
+
+```js
+axios.post('/user', {
+    firstName: 'Fred',
+    lastName: 'Flintstone'
+  })
+  .then(function (response) {
+    console.log(response);
+  })
+  .catch(function (error) {
+    console.log(error);
+  });
+```
+
+複数のリクエストの並列処理
+
+```js
+function getUserAccount() {
+  return axios.get('/user/12345');
+}
+
+function getUserPermissions() {
+  return axios.get('/user/12345/permissions');
+}
+
+Promise.all([getUserAccount(), getUserPermissions()])
+  .then(function (results) {
+    const acct = results[0];
+    const perm = results[1];
+  });
+```

--- a/posts/ja/req_config.md
+++ b/posts/ja/req_config.md
@@ -1,0 +1,184 @@
+---
+title: 'リクエスト設定'
+prev_title: 'Axios インスタンス'
+prev_link: '/docs/instance'
+next_title: 'レスポンス スキーマ'
+next_link: '/docs/res_schema'
+---
+
+
+これらは、リクエストを行う際に利用可能な設定オプションです。`url` だけが必須です。`method` が指定されていない場合、リクエストのデフォルトは `GET` です。
+
+```js
+{
+  // `url` はリクエストに使用されるサーバーの URL です。
+  url: '/user',
+
+  // `method` はリクエストを行う際に使用されるリクエストメソッドです。
+  method: 'get', // default
+
+  // `url` が絶対パス指定でない限り、`baseURL` が `url` の前に付加されます。
+  // Axios のインスタンスに `baseURL` を設定すると、そのインスタンスのメソッドに相対パスで
+  // URLを渡すことができ、便利です。
+  baseURL: 'https://some-domain.com/api',
+
+  // `transformRequest` は、サーバーに送信される前にリクエスト データを変更できるようにします。
+  // これはリクエスト メソッドの 'PUT'、'POST'、PATCH'、'DELETE' に対してのみ適用されます。
+  // 配列の最後の関数は、文字列または Buffer、ArrayBuffer、FormData、Stream のインスタンスを返す必要があります。
+  // ヘッダー オブジェクトを変更できます。
+  transformRequest: [function (data, headers) {
+    // データの変換処理を行います
+
+    return data;
+  }],
+
+  // `transformResponse` を使用すると、レスポンス データを変更してから then/catch に渡すことができます。
+  transformResponse: [function (data) {
+    // データの変換処理を行います
+
+    return data;
+  }],
+
+  // `headers` は送信されるカスタム ヘッダーです。
+  headers: {'X-Requested-With': 'XMLHttpRequest'},
+
+  // `params` は、リクエストとともに送信される URL パラメータです。
+  // プレーンオブジェクトまたは URLSearchParams オブジェクトである必要があります。
+  // 注: null または未定義のパラメーターは URL にレンダリングされません。
+  params: {
+    ID: 12345
+  },
+
+  // `paramsSerializer` は、 `params` のシリアライズを担当するオプションの関数です。
+  // (たとえば、https://www.npmjs.com/package/qs、http://api.jquery.com/jquery.param/)
+  paramsSerializer: function (params) {
+    return Qs.stringify(params, {arrayFormat: 'brackets'})
+  },
+
+  // `data` はリクエスト ボディとして送信されるデータです。
+  // リクエスト メソッド 'PUT'、'POST'、'DELETE'、'PATCH' に対してのみ適用可能です。
+  // `transformRequest` が設定されていない場合は、以下のいずれかの型でなければなりません。
+  // - string, plain object, ArrayBuffer, ArrayBufferView, URLSearchParams
+  // - ブラウザのみ: FormData, File, Blob
+  // - Node.js のみ: Stream, Buffer
+  data: {
+    firstName: 'Fred'
+  },
+  
+  // ボディにデータを送信するための代替構文
+  // メソッド ポスト
+  // キーではなく、値のみが送信されます。
+  data: 'Country=Brasil&City=Belo Horizonte',
+
+  // `timeout`は、リクエストがタイムアウトするまでのミリ秒数を指定します。
+  // リクエストに`timeout`より長い時間がかかる場合、リクエストは中止されます。
+  timeout: 1000, // デフォルトは `0` (タイムアウトなし)
+
+  // `withCredentials` は、資格情報を使用してクロスサイト アクセスコントロールの
+  // リクエストを行うかどうかを示します。
+  withCredentials: false, // デフォルト
+
+  // `adapter`を使用すると、リクエストをカスタム処理できるため、テストが簡単になります。
+  // Promise を返し、有効なレスポンスを提供します (lib/adapters/README.md を参照)。
+  adapter: function (config) {
+    /* ... */
+  },
+
+  // `auth` は、HTTP 基本認証を使用する必要があることを示し、資格情報を提供します。
+  // これにより、 `Authorization` ヘッダーが設定され、`headers` を使用して設定した
+  // 既存の `Authorization` カスタムヘッダーを上書きします。
+  // このパラメーターを使用して構成できるのは、HTTP 基本認証のみであることに注意してください。
+  // Bearer トークンなどの場合は、代わりに `Authorization` カスタム ヘッダーを使用してください。
+  auth: {
+    username: 'janedoe',
+    password: 's00pers3cret'
+  },
+
+  // `responseType` には、以下のようなサーバーがオプションで応答するデータのタイプを指定します。
+  // 'arraybuffer'、'document'、'json'、'text'、'stream'
+  //   browser のみ: 'blob'
+  responseType: 'json', // デフォルト
+
+  // `responseEncoding` には、レスポンスのデコードで使用するエンコード方法を指定します (Node.js のみ)
+  // 注: `responseType` が 'stream' の場合、あるいはクライアントサイドのリクエストの場合は無視されます。
+  responseEncoding: 'utf8', // デフォルト
+
+  // `xsrfCookieName` は、xsrf トークンの値として使用する Cookie の名前です。
+  xsrfCookieName: 'XSRF-TOKEN', // デフォルト
+
+  // `xsrfHeaderName` は、xsrf トークン値を格納する http ヘッダーの名前です。
+  xsrfHeaderName: 'X-XSRF-TOKEN', // デフォルト
+
+  // `onUploadProgress` を使用すると、アップロードの進行状況イベントを処理できます。
+  // ブラウザのみ
+  onUploadProgress: function (progressEvent) {
+    // ネイティブの進行状況イベントを処理します
+  },
+
+  // `onDownloadProgress` を使用すると、ダウンロードの進行状況イベントを処理できます。
+  // ブラウザのみ
+  onDownloadProgress: function (progressEvent) {
+    // ネイティブの進行状況イベントを処理します
+  },
+
+  // `maxContentLength` は Node.js で許可される http レスポンスのコンテンツの最大サイズをバイト数で定義します。
+  maxContentLength: 2000,
+
+  // `maxBodyLength` (Node.js のみのオプション) は、http リクエストのコンテンツの最大サイズをバイト数で定義します
+  maxBodyLength: 2000,
+
+  // `validateStatus` は、与えられた HTTP レスポンスのステータスコードに対して、Promise を解決するか拒否するかを定義します。
+  // `validateStatus` が `true` を返す場合 (または `null` や `undefined` に設定されている場合) Promise は解決されます。
+  // それ以外の場合は Promise は拒否されます。
+  validateStatus: function (status) {
+    return status >= 200 && status < 300; // デフォルト
+  },
+
+  // `maxRedirects` は Node.js でリダイレクトをたどる最大数を定義します。
+  // 0 に設定すると、リダイレクトは実行されません。
+  maxRedirects: 5, // デフォルト
+
+  // `socketPath` は、Node.js で使用する UNIX ソケットを定義します。
+  // 例えば '/var/run/docker.sock' を使用して、Docker デーモンにリクエストを送信します。
+  // 指定できるのは `socketPath` または `proxy` のいずれかのみです。
+  // 両方を指定すると、`socketPath` が使用されます。
+  socketPath: null, // デフォルト
+
+  // `httpAgent` と `httpsAgent` は、それぞれ Node.js で http と https のリクエストを
+  // 実行するときに使用するカスタムエージェントを定義します。
+  // これにより、デフォルトでは有効になっていない `keepAlive` のようなオプションを追加できます。
+  httpAgent: new http.Agent({ keepAlive: true }),
+  httpsAgent: new https.Agent({ keepAlive: true }),
+
+  // `proxy` は、プロキシサーバーのホスト名、ポート、プロトコルを定義します。
+  // また、従来の `http_proxy` と `https_proxy` 環境変数を使用して、プロキシを定義することもできます。
+  // プロキシの設定に環境変数を使用する場合、プロキシを設定しないドメインのカンマ区切りのリストとして
+  // `no_proxy` 環境変数を定義することもできます。
+  // 環境変数を無視してプロキシを無効にするには、 `false` を使用します。
+  // `auth` は、プロキシへの接続に HTTP 基本認証を使用することを示し、認証情報を提供します。
+  // これにより、`Proxy-Authorization` ヘッダーが設定され、`headers` を使用して設定した既存の
+  // `Proxy-Authorization` カスタムヘッダーが上書きされます。
+  // プロキシサーバーが HTTPS を使用する場合は、プロトコルを `https` に設定する必要があります。 
+  proxy: {
+    protocol: 'https',
+    host: '127.0.0.1',
+    port: 9000,
+    auth: {
+      username: 'mikeymike',
+      password: 'rapunz3l'
+    }
+  },
+
+  // `cancelToken` には、リクエストをキャンセルするために使用するキャンセル トークンを指定します
+  // (詳細は後述のキャンセルのセクションを参照してください)。
+  cancelToken: new CancelToken(function (cancel) {
+  }),
+
+  // `decompress` は、レスポンス ボディを自動的に解凍するかどうかを示します。
+  // `true` に設定すると、すべての解凍されたレスポンスのレスポンス オブジェクトから
+  // 'content-encoding' ヘッダーも削除されます。
+  // - ノードのみ (XHR は解凍をオフにできません)
+  decompress: true // デフォルト
+
+}
+```

--- a/posts/ja/res_schema.md
+++ b/posts/ja/res_schema.md
@@ -1,0 +1,52 @@
+---
+title: 'レスポンス スキーマ'
+prev_title: 'リクエスト設定'
+prev_link: '/docs/req_config'
+next_title: 'デフォルト設定'
+next_link: '/docs/config_defaults'
+---
+
+リクエストに対するレスポンスには、以下の情報が含まれます。
+
+```js
+{
+  // `data` はサーバーから提供されたレスポンスです。
+  data: {},
+
+  // `status` はサーバーのレスポンスに含まれる HTTP ステータスコードです。
+  status: 200,
+
+  // `statusText` はサーバーのレスポンスに含まれる HTTP ステータスメッセージです。
+  // HTTP/2 の場合、ステータス テキストは空白または未対応 (unsupported) です。
+  // (HTTP/2 RFC: https://www.rfc-editor.org/rfc/rfc7540#section-8.1.2.4)
+  statusText: 'OK',
+
+  // `headers` サーバーが応答した HTTP ヘッダー
+  // ヘッダー名はすべて小文字で、ブラケット記法でアクセスできます。
+  // 例: `response.headers['content-type']`
+  headers: {},
+
+  // `config` はリクエストの際に `axios` に提供された設定です。
+  config: {},
+
+  // `request` は、このレスポンスを生成したリクエストです
+  // これは、Node.js (リダイレクト内) の最後の ClientRequest インスタンスであり、
+  // ブラウザーの XMLHttpRequest インスタンスです。
+  request: {}
+}
+```
+
+`then` を使用すると、次のようなレスポンスが返されます。
+
+```js
+axios.get('/user/12345')
+  .then(function (response) {
+    console.log(response.data);
+    console.log(response.status);
+    console.log(response.statusText);
+    console.log(response.headers);
+    console.log(response.config);
+  });
+```
+
+`catch` を使用する場合、または `then` の 2番目のパラメーターとして [拒否コールバック](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/then) を渡す場合、 [エラー処理](https://axios-http.com/docs/handling_errors) セクションで説明されているように、レスポンスは `error` オブジェクトを介して利用できます。

--- a/posts/ja/translating.md
+++ b/posts/ja/translating.md
@@ -1,0 +1,46 @@
+---
+title: 'ドキュメントの翻訳'
+---
+
+Axios をできるだけ多くの人が利用できるようにするには、これらのドキュメントをすべての言語で読めるようにすることが重要です。ドキュメントの翻訳にご協力いただける方はいつでも歓迎いたします。このガイドでは、このドキュメントに翻訳を追加する手順を説明します。
+
+## 構造
+
+すべての翻訳は、設定ファイル `{language-shortcut}.lang.js` (例えば `en.lang.js` や `de.lang.js`) と、 `posts/{language-shortcut}/*.md` (例えば `posts/en` や `posts/de`) の翻訳ドキュメントファイルから構成されています。`{language-shortcut}` は、あなたの言語の [ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1) の 2文字コードに置き換える必要があります。
+
+## 言語を設定する
+
+- `en.lang.js` をコピーします。
+- 名前を `{language-shortcut}.lang.js` に変更します。
+- `display` をあなたの言語の名前に置き換えてください。 たとえば、ドイツ語を翻訳する場合は、「German」を「Deutsch」に書き換えます。
+- プレフィックスを `/{language-shortcut}/` に置き換えます。
+- `p` と `t` フィールドの値を翻訳します。
+- `sidebar` の `text` というラベルの付いたすべてのプロパティを翻訳します。 **注:** このドキュメントの最新バージョン以降、サイドバーのリンクを更新する必要はありません。
+
+### コンフィギュレーションを登録する
+
+言語の設定と、設定ファイル内のフレーズやリンクの翻訳が終わったら、それをルート設定に登録する必要があります。これを行うには、`inert.config.js` を開き、先頭付近に以下の行を追加します。
+
+```js
+const {language-shortcut}Config = require('./{language-shortcut}.config.js');
+```
+
+もちろん、`{language-shortuct}` を正しい [ISO 369-1](https://en.wikipedia.org/wiki/ISO_639-1) コードに置き換えることを忘れないでください (変数名にも書いてあります!)。
+
+ここで、定数 `langs` を探します。この定数が `require` 文の上にある場合は、 `require` 文をその上に移動してください。`langs` のリストに、次のオブジェクトを追加してください。
+
+```js
+const langs = [
+  ...
+  {
+    name: '"英語 "や "ドイツ語 "など、言語を一意に識別できる名前',
+    prefix: "設定ファイルと同じプレフィックス",
+    config: {language-shortcut}Config // 先ほどインポートした Config オブジェクト
+  }
+  ...
+];
+```
+
+これで、ファイルの翻訳を開始できます。フォルダ `posts/en` を新しいフォルダ `posts/{language-shortcut}` にコピーし、すべてのファイルを翻訳します (もちろん、ファイル名は翻訳しないでください)。
+
+問題が発生した場合は、[イシューを作成](https://github.com/axios/axios-docs/issues/new/choose) してください。

--- a/posts/ja/urlencoded.md
+++ b/posts/ja/urlencoded.md
@@ -1,0 +1,94 @@
+---
+title: 'URL-エンコードボディ'
+prev_title: 'キャンセル'
+prev_link: '/docs/cancellation'
+next_title: '特記事項'
+next_link: '/docs/notes'
+---
+
+デフォルトでは、Axios は JavaScript オブジェクトを `JSON` にシリアライズします。代わりに `application/x-www-form-urlencoded` 形式でデータを送信するには、次のいずれかのオプションを使用します。
+
+### ブラウザ
+
+ブラウザでは、以下のように [`URLSearchParams`](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams) の API を使用できます。
+
+```js
+const params = new URLSearchParams();
+params.append('param1', 'value1');
+params.append('param2', 'value2');
+axios.post('/foo', params);
+```
+
+> なお、`URLSearchParams` はすべてのブラウザでサポートされているわけではありませんが (参照: [caniuse.com](http://www.caniuse.com/#feat=urlsearchparams))、[polyfill](https://github.com/WebReflection/url-search-params) が利用できます (必ずグローバル環境をポリフィルしてください)。
+
+または、以下のように [`qs`](https://github.com/ljharb/qs) ライブラリを使用してデータをエンコードすることもできます。
+
+```js
+const qs = require('qs');
+axios.post('/foo', qs.stringify({ 'bar': 123 }));
+```
+
+あるいは別の方法 (ES6) でも。
+
+```js
+import qs from 'qs';
+const data = { 'bar': 123 };
+const options = {
+  method: 'POST',
+  headers: { 'content-type': 'application/x-www-form-urlencoded' },
+  data: qs.stringify(data),
+  url,
+};
+axios(options);
+```
+
+### Node.js
+
+#### クエリ文字列
+
+Node.js では、以下のように [`querystring`](https://nodejs.org/api/querystring.html) モジュールを使用することができます。
+
+```js
+const querystring = require('querystring');
+axios.post('http://something.com/', querystring.stringify({ foo: 'bar' }));
+```
+
+または、['url module'](https://nodejs.org/api/url.html) に定義された ['URLSearchParams'](https://nodejs.org/api/url.html#url_class_urlsearchparams) を以下のように使用します。
+
+```js
+const url = require('url');
+const params = new url.URLSearchParams({ foo: 'bar' });
+axios.post('http://something.com/', params.toString());
+```
+
+また、[`qs`](https://github.com/ljharb/qs) ライブラリを使用することもできます。
+
+###### 注
+
+ネストしたオブジェクトを文字列化する必要がある場合は、`qs` ライブラリが適しています。なぜなら、 `querystring` メソッドには、その使用例に対して既知の問題があるからです (https://github.com/nodejs/node-v0.x-archive/issues/1665)。
+
+#### フォームデータ
+
+Node.js では、以下のように [`form-data`](https://github.com/form-data/form-data) ライブラリを使用することができます。
+
+```js
+const FormData = require('form-data');
+ 
+const form = new FormData();
+form.append('my_field', 'my value');
+form.append('my_buffer', new Buffer(10));
+form.append('my_file', fs.createReadStream('/foo/bar.jpg'));
+
+axios.post('https://example.com', form, { headers: form.getHeaders() })
+```
+
+または、以下のようにインターセプターを使用します。
+
+```js
+axios.interceptors.request.use(config => {
+  if (config.data instanceof FormData) {
+    Object.assign(config.headers, config.data.getHeaders());
+  }
+  return config;
+});
+```


### PR DESCRIPTION
Add Japanese translation (locale: `ja`)

- add `ja` configuration to `inert.config.js`
- add `ja.lang.js` files, that is translated
- add `posts/ja/*.md` files, that are translated

