### PR TITLE
fix:Typo In Documentation

### DIFF
--- a/posts/en/multipart.md
+++ b/posts/en/multipart.md
@@ -31,7 +31,7 @@ axios.postForm('https://httpbin.org/post', {
 });
 ```
 
-HTML form can be passes directly as a request payload
+HTML form can be passed directly as a request payload
 
 #### Node.js
 


### PR DESCRIPTION
This PR Resolves a Typo in the multipart bodies page of the documentation 
#5847
