### PR TITLE
fix: On the documentation page for Multipart Bodies HTML form can be passed

### DIFF
--- a/posts/en/multipart.md
+++ b/posts/en/multipart.md
@@ -31,7 +31,7 @@ axios.postForm('https://httpbin.org/post', {
 });
 ```
 
-HTML form can be passes directly as a request payload
+HTML form can be passed directly as a request payload
 
 #### Node.js
 


### PR DESCRIPTION
fix: On the documentation page for Multipart Bodies HTML form can be passed instead of passes directly as a request payload. 
fixed issue : #5847