### PR TITLE
fix: prevent heading lines overlap with navbar in desktop mode

### DIFF
--- a/scss/home.scss
+++ b/scss/home.scss
@@ -92,6 +92,10 @@ section#hero {
     .buttons {
       margin-left: -1.5rem;
     }
+    // media query to prevent navbar from overlapping with the heading on desktop
+    @media screen and (min-width: 1024px) {
+      margin-top: 40px;
+    }
   }
 }
 


### PR DESCRIPTION
## Changes Made
Adjusted the `margin-top` property for the heading lines within `section#hero div.content` to ensure proper spacing. This resolves the issue of overlap with the navigation bar in desktop mode.

## Preview
Here's how the page looks after the fix:


https://github.com/axios/axios-docs/assets/82380855/ecf1fc33-c0a5-4d8f-908c-0e56629a365b




