### PR TITLE
[Fixed] passes is swapped with passed in multipart page

### DIFF
--- a/posts/en/multipart.md
+++ b/posts/en/multipart.md
@@ -31,7 +31,7 @@ axios.postForm('https://httpbin.org/post', {
 });
 ```
 
-HTML form can be passes directly as a request payload
+HTML form can be passed directly as a request payload
 
 #### Node.js
 


### PR DESCRIPTION
### What change does this PR introduce?

This PR Fixes #133 typo in multipart docs page in `posts/en/multipart.md`