### PR TITLE
Added features and fixes to Spanish docs

### DIFF
--- a/posts/es/api_intro.md
+++ b/posts/es/api_intro.md
@@ -1,10 +1,10 @@
 ---
-title: 'API de Axios'
-description: 'Referencia del API de Axios'
-prev_title: 'Petición Post'
-prev_link: '/es/docs/post_example'
-next_title: 'La instancia Axios'
-next_link: '/es/docs/instance'
+title: "API de Axios"
+description: "Referencia del API de Axios"
+prev_title: "Petición Post"
+prev_link: "/es/docs/post_example"
+next_title: "La instancia Axios"
+next_link: "/es/docs/instance"
 ---
 
 Las peticiones pueden ser hechas pasando la configuración relevante a `axios`.
@@ -14,47 +14,53 @@ Las peticiones pueden ser hechas pasando la configuración relevante a `axios`.
 ```js
 // Enviar una petición POST
 axios({
-  method: 'post',
-  url: '/user/12345',
+  method: "post",
+  url: "/user/12345",
   data: {
-    firstName: 'Fred',
-    lastName: 'Flintstone'
-  }
+    firstName: "Fred",
+    lastName: "Flintstone",
+  },
 });
 ```
 
 ```js
 // Petición GET para una imagen remota en node.js
 axios({
-  method: 'get',
-  url: 'http://bit.ly/2mTM3nY',
-  responseType: 'stream'
-})
-  .then(function (response) {
-    response.data.pipe(fs.createWriteStream('ada_lovelace.jpg'))
-  });
+  method: "get",
+  url: "http://bit.ly/2mTM3nY",
+  responseType: "stream",
+}).then(function (response) {
+  response.data.pipe(fs.createWriteStream("ada_lovelace.jpg"));
+});
 ```
 
 ##### axios(url[, config])
 
 ```js
 // Enviar petición GET (método por defecto)
-axios('/user/12345');
+axios("/user/12345");
 ```
 
 ### Alias de metodos de petición
 
-Por conveniencia los alias han sido proveídos para todos los métodos de petición.
+Para mayor conveniencia, se han proporcionado alias para todos los métodos de petición.
 
 ##### axios.request(config)
+
 ##### axios.get(url[, config])
+
 ##### axios.delete(url[, config])
+
 ##### axios.head(url[, config])
+
 ##### axios.options(url[, config])
+
 ##### axios.post(url[, data[, config]])
+
 ##### axios.put(url[, data[, config]])
 
 ##### axios.patch(url[, data[, config]])
 
 ###### NOTA
+
 Al usar los alias, las propiedades `url`, `method`, y `data` no necesitan ser especificadas en la configuración.

--- a/posts/es/cancellation.md
+++ b/posts/es/cancellation.md
@@ -6,6 +6,21 @@ next_title: "Cuerpos de solicitud codificados como URL"
 next_link: "/es/docs/urlencoded"
 ---
 
+## Cancelando peticiones
+
+Configurar la propiedad `timeout` en una llamada axios gestiona los tiempos de espera relacionados con la **respuesta**.
+
+In some cases (e.g. network connection becomes unavailable) an axios call would benefit from cancelling the **connection** early. Without cancellation, the axios call can hang until the parent code/stack times out (might be a few minutes in a server-side applications).
+
+En algunos casos (por ejemplo, si la conexión de red se interrumpe), sería beneficioso cancelar la **connection** de la llamada axios de manera temprana. Sin esta cancelación, la llamada axios puede quedar suspendida hasta que el código base (o la pila principal) alcance el tiempo de espera (puede ser de unos minutos en aplicaciones del lado del servidor).
+
+Para terminar una llamada axios, puedes usar uno de los siguientes métodos:
+
+- `signal`
+- `cancelToken` (obsoleto)
+
+Combinar `timeout` y algún método de cancelación (por ejemplo, `signal`), debería cubrir los tiempos de espera tanto de la **response** como de la **connection**.
+
 ## AbortController
 
 Empezando desde `v0.22.0` Axios soporta el [`AbortController`](https://developer.mozilla.org/en-US/docs/Web/API/AbortController) para cancelar peticiones de la misma forma que la API de fetch:
@@ -30,9 +45,9 @@ También puedes cancelar una petición usando un _CancelToken_.
 
 > La API token de cancelación está basado en la propuesta [propuesta para cancelar promesas](https://github.com/tc39/proposal-cancelable-promises).
 
-> Esta API es obsoleto desde `v0.22.0` y no debería ser usada en proyectos nuevos
+> Esta API está obsoleta desde `v0.22.0` y no debería ser usada en nuevos proyectos.
 
-Puedes crear un token de cancelación usando el factory `CancelToken.source` a como se muestra a continuación:
+Puedes crear un token de cancelación usando el factory `CancelToken.source`, como se muestra a continuación:
 
 ```js
 const CancelToken = axios.CancelToken;
@@ -83,7 +98,7 @@ cancel();
 
 > Nota: puedes cancelar muchas peticiones con el mismo token / signal.
 
-Durante el periodo de transición, puedes usar ambas APIs de cancelación, aun para la misma petición:
+Durante el período de transición, puedes usar ambas APIs de cancelación, aun para la misma petición:
 
 ```js
 const controller = new AbortController();

--- a/posts/es/config_defaults.md
+++ b/posts/es/config_defaults.md
@@ -1,9 +1,9 @@
 ---
-title: 'Configuraciones por Defecto'
-prev_title: 'Esquema de Respuesta'
-prev_link: '/es/docs/res_schema'
-next_title: 'Interceptores'
-next_link: '/es/docs/interceptors'
+title: "Configuraciones por Defecto"
+prev_title: "Esquema de Respuesta"
+prev_link: "/es/docs/res_schema"
+next_title: "Interceptores"
+next_link: "/es/docs/interceptors"
 ---
 
 ## Configuraciones por Defecto
@@ -13,29 +13,30 @@ Puedes especificar configuraciones por defecto que serán aplicadas a cada petic
 ### Valores globales predeterminados de axios
 
 ```js
-axios.defaults.baseURL = 'https://api.example.com';
-axios.defaults.headers.common['Authorization'] = AUTH_TOKEN;
-axios.defaults.headers.post['Content-Type'] = 'application/x-www-form-urlencoded';
+axios.defaults.baseURL = "https://api.example.com";
+axios.defaults.headers.common["Authorization"] = AUTH_TOKEN;
+axios.defaults.headers.post["Content-Type"] =
+  "application/x-www-form-urlencoded";
 ```
 
 ### Valores predeterminados de instancias personalizadas
 
 ```js
-// Establecer configuraciones por defecto al crear la instancia
+// Establece configuraciones por defecto al crear la instancia
 const instance = axios.create({
-  baseURL: 'https://api.example.com'
+  baseURL: "https://api.example.com",
 });
 
-// Modificar valores por defecto después que una instancia ha sido creada
-instance.defaults.headers.common['Authorization'] = AUTH_TOKEN;
+// Modifica valores por defecto después que una instancia ha sido creada
+instance.defaults.headers.common["Authorization"] = AUTH_TOKEN;
 ```
 
 ### Configurar orden de precedencia
 
-La configuración será combinada en orden de precedencia. El orden es: valores predeterminados de la biblioteca que se encuentran en [lib/defaults.js](https://github.com/axios/axios/blob/master/lib/defaults.js#L28), luego la propiedad `defaults` de la instancia, y finalmente el argumento `config` de la petición. Este último tendrá prioridad sobre el primero. Aquí hay un ejemplo.
+La configuración será combinada en orden de precedencia. El orden es: valores predeterminados de la biblioteca que se encuentran en [lib/defaults.js](https://github.com/axios/axios/blob/master/lib/defaults.js#L28), luego la propiedad `defaults` de la instancia, y finalmente el argumento `config` de la petición. Este último tendrá prioridad sobre el primero. Aquí hay un ejemplo:
 
 ```js
-// Crear una instancia usando la configuración por defecto proveída por la librería
+// Crear una instancia usando la configuración por defecto proporcionada por la librería
 // En este punto el valor del tiempo de espera es `0`, ya que es el valor predeterminado de la librería.
 const instance = axios.create();
 
@@ -44,7 +45,7 @@ const instance = axios.create();
 instance.defaults.timeout = 2500;
 
 // Sobrescribir el tiempo máximo de espera cuando se sabe que la petición tomara mucho tiempo
-instance.get('/longRequest', {
-  timeout: 5000
+instance.get("/longRequest", {
+  timeout: 5000,
 });
 ```

--- a/posts/es/example.md
+++ b/posts/es/example.md
@@ -1,17 +1,18 @@
 ---
-title: 'Ejemplo Mínimo'
-description: 'Un ejemplo pequeño de como usar Axios'
-prev_title: 'Introducción'
-prev_link: '/es/docs/intro'
-next_title: 'Petición POST'
-next_link: '/es/docs/post_example'
+title: "Ejemplo Mínimo"
+description: "Un ejemplo pequeño de como usar Axios"
+prev_title: "Introducción"
+prev_link: "/es/docs/intro"
+next_title: "Petición POST"
+next_link: "/es/docs/post_example"
 ---
 
 ## nota: Uso de CommonJS
-Para aprovechar la tipificación de TypeScript (para intellisense / autocompletado) usa el próximo enfoque al utilizar los imports de CommonJS con `require()`:
+
+Para aprovechar la tipificación de TypeScript (para intellisense / autocompletado), usa el próximo enfoque al utilizar los imports de CommonJS con `require()`:
 
 ```js
-const axios = require('axios').default;
+const axios = require("axios").default;
 
 // axios.<method> proveerá autocompletado y tipificación  de parámetros
 ```
@@ -21,10 +22,11 @@ const axios = require('axios').default;
 Ejecutado una petición `GET`
 
 ```js
-const axios = require('axios');
+const axios = require("axios");
 
 // Hacer una petición para un usuario con ID especifico
-axios.get('/user?ID=12345')
+axios
+  .get("/user?ID=12345")
   .then(function (response) {
     // manejar respuesta exitosa
     console.log(response);
@@ -38,10 +40,11 @@ axios.get('/user?ID=12345')
   });
 
 // Opcionalmente, la solicitud anterior también se puede realizar como
-axios.get('/user', {
+axios
+  .get("/user", {
     params: {
-      ID: 12345
-    }
+      ID: 12345,
+    },
   })
   .then(function (response) {
     console.log(response);
@@ -51,12 +54,12 @@ axios.get('/user', {
   })
   .finally(function () {
     // siempre sera ejecutado
-  });  
+  });
 
 // ¿Quieres usar async/await? Añade la palabra reservada `async` a tu función/método externo.
 async function getUser() {
   try {
-    const response = await axios.get('/user?ID=12345');
+    const response = await axios.get("/user?ID=12345");
     console.log(response);
   } catch (error) {
     console.error(error);
@@ -65,4 +68,4 @@ async function getUser() {
 ```
 
 > **NOTA:** `async/await` es parte de ECMAScript 2017 y no es soportado por Internet
-> Explorer y otros navegadores antiguos, a si que usalo con cuidado.
+> Explorer y otros navegadores antiguos, así que debe utilizarse con cuidado.

--- a/posts/es/handling_errors.md
+++ b/posts/es/handling_errors.md
@@ -1,48 +1,46 @@
 ---
-title: 'Manejando Errores'
-prev_title: 'Interceptores'
-prev_link: '/es/docs/interceptors'
-next_title: 'Cancelación'
-next_link: '/es/docs/cancellation'
+title: "Manejando Errores"
+prev_title: "Interceptores"
+prev_link: "/es/docs/interceptors"
+next_title: "Cancelación"
+next_link: "/es/docs/cancellation"
 ---
 
 ```js
-axios.get('/user/12345')
-  .catch(function (error) {
-    if (error.response) {
-      // La respuesta fue hecha y el servidor respondió con un código de estado
-      // que esta fuera del rango de 2xx
-      console.log(error.response.data);
-      console.log(error.response.status);
-      console.log(error.response.headers);
-    } else if (error.request) {
-      // La petición fue hecha pero no se recibió respuesta
-      // `error.request` es una instancia de XMLHttpRequest en el navegador y una instancia de
-      // http.ClientRequest en node.js
-      console.log(error.request);
-    } else {
-      // Algo paso al preparar la petición que lanzo un Error
-      console.log('Error', error.message);
-    }
-    console.log(error.config);
-  });
+axios.get("/user/12345").catch(function (error) {
+  if (error.response) {
+    // Se realizó la petición y el servidor respondió con un código de estado
+    // que esta fuera del rango de 2xx
+    console.log(error.response.data);
+    console.log(error.response.status);
+    console.log(error.response.headers);
+  } else if (error.request) {
+    // Se realizó la peticón pero no se recibió respuesta
+    // `error.request` es una instancia de XMLHttpRequest en el navegador y una instancia de
+    // http.ClientRequest en node.js
+    console.log(error.request);
+  } else {
+    // Algo sucedió al preparar la petición que provocó un Error
+    console.log("Error", error.message);
+  }
+  console.log(error.config);
+});
 ```
 
-Usando la opción de configuración `validateStatus`, puedes definir los codigo(s) HTTP que deberán lanzar un error.
+Usando la opción de configuración `validateStatus`, puedes definir los código(s) HTTP que deberán lanzar un error.
 
 ```js
-axios.get('/user/12345', {
+axios.get("/user/12345", {
   validateStatus: function (status) {
     return status < 500; // Resuelve solo si el código de estado es menor que 500
-  }
-})
+  },
+});
 ```
 
-Usando `toJSON` obtienes un objeto con mas información sobre el error HTTP.
+Usando `toJSON` obtienes un objeto con más información sobre el error HTTP.
 
 ```js
-axios.get('/user/12345')
-  .catch(function (error) {
-    console.log(error.toJSON());
-  });
+axios.get("/user/12345").catch(function (error) {
+  console.log(error.toJSON());
+});
 ```

--- a/posts/es/interceptors.md
+++ b/posts/es/interceptors.md
@@ -1,39 +1,47 @@
 ---
-title: 'Interceptores'
-prev_title: 'Configuraciones por Defecto'
-prev_link: '/es/docs/config_defaults'
-next_title: 'Manejando Errores'
-next_link: '/es/docs/handling_errors'
+title: "Interceptores"
+prev_title: "Configuraciones por Defecto"
+prev_link: "/es/docs/config_defaults"
+next_title: "Manejando Errores"
+next_link: "/es/docs/handling_errors"
 ---
 
-Puedes interceptar peticiones o respuestas antes que sean manipulados por `then` o `catch`. 
+Puedes interceptar peticiones o respuestas antes que sean manipulados por `then` o `catch`.
 
 ```js
 // Agregar un interceptor a la petición
-axios.interceptors.request.use(function (config) {
+axios.interceptors.request.use(
+  function (config) {
     // Haz algo antes que la petición se ha enviada
     return config;
-  }, function (error) {
+  },
+  function (error) {
     // Haz algo con el error de la petición
     return Promise.reject(error);
-  });
+  }
+);
 
 // Agregar una respuesta al interceptor
-axios.interceptors.response.use(function (response) {
-    // Cualquier código de estado que este dentro del rango de 2xx causa la ejecución de esta función 
+axios.interceptors.response.use(
+  function (response) {
+    // Cualquier código de estado que esté dentro del rango de 2xx causa la ejecución de esta función
     // Haz algo con los datos de la respuesta
     return response;
-  }, function (error) {
+  },
+  function (error) {
     // Cualquier código de estado que este fuera del rango de 2xx causa la ejecución de esta función
     // Haz algo con el error
     return Promise.reject(error);
-  });
+  }
+);
 ```
 
-Si necesitas remover un interceptor después, puedes hacerlo.
+Si necesitas eliminar un interceptor más adelante, puedes hacerlo.
 
 ```js
-const myInterceptor = axios.interceptors.request.use(function () {/*...*/});
+const myInterceptor = axios.interceptors.request.use(function () {
+  /*...*/
+});
 axios.interceptors.request.eject(myInterceptor);
 ```
 
@@ -41,5 +49,7 @@ Puedes agregar interceptores a una instancia personalizada de axios.
 
 ```js
 const instance = axios.create();
-instance.interceptors.request.use(function () {/*...*/});
+instance.interceptors.request.use(function () {
+  /*...*/
+});
 ```

--- a/posts/es/intro.md
+++ b/posts/es/intro.md
@@ -1,14 +1,36 @@
 ---
-title: 'Empezando'
-description: 'Cliente HTTP simple basado en promesas para el navegador y node.js'
-next_title: 'Ejemplo Mínimo'
-next_link: '/es/docs/example'
+title: "Empezando"
+description: "Cliente HTTP simple basado en promesas para el navegador y node.js"
+next_title: "Ejemplo Mínimo"
+next_link: "/es/docs/example"
 ---
 
 # ¿Qué es Axios?
-Axios es un Cliente HTTP *[basado en promesas](https://javascript.info/promise-basics)* para [`node.js`](https://nodejs.org) y el navegador. Es *[isomorfico](https://www.lullabot.com/articles/what-is-an-isomorphic-application)* (= puede ejecutarse en el navegador y nodejs con el mismo código base). En el lado del servidor usa el modulo nativo `http` de node.js, mientras que en el lado del cliente (navegador) usa XMLHttpRequests.
 
-# Caracteristicas
+Axios es un Cliente HTTP _[basado en promesas](https://javascript.info/promise-basics)_ para [`node.js`](https://nodejs.org) y el navegador. Es _[isomorfico](https://www.lullabot.com/articles/what-is-an-isomorphic-application)_ (= puede ejecutarse en el navegador y nodejs con el mismo código base). En el lado del servidor usa el modulo nativo `http` de node.js, mientras que en el lado del cliente (navegador) usa XMLHttpRequests.
+
+# Features
+
+- Make [XMLHttpRequests](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest) from the browser
+- Make [http](http://nodejs.org/api/http.html) requests from node.js
+- Supports the [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) API
+- Intercept request and response
+- Transform request and response data
+- Cancel requests
+- Timeouts
+- Query parameters serialization with support for nested entries
+- Automatic request body serialization to:
+  - JSON (`application/json`)
+  - Multipart / FormData (`multipart/form-data`)
+  - URL encoded form (`application/x-www-form-urlencoded`)
+- Posting HTML forms as JSON
+- Automatic JSON data handling in response
+- Progress capturing for browsers and node.js with extra info (speed rate, remaining time)
+- Setting bandwidth limits for node.js
+- Compatible with spec-compliant FormData and Blob (including `node.js`)
+- Client side support for protecting against [XSRF](http://en.wikipedia.org/wiki/Cross-site_request_forgery)
+
+# Características
 
 - Hace [XMLHttpRequests](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest) desde el navegador
 - Hace peticiones [http](http://nodejs.org/api/http.html) desde node.js
@@ -16,7 +38,17 @@ Axios es un Cliente HTTP *[basado en promesas](https://javascript.info/promise-b
 - Intercepta petición y respuesta
 - Transforma petición y datos de respuesta
 - Cancela peticiones
-- Transformacion automatica de datos JSON
+- Tiempos de espera
+- Serialización de parámetros de consulta (query parameters) con soporte para entradas anidadas
+- Serialización del cuerpo (body) de la petición a:
+  - JSON (`application/json`)
+  - Multipart / FormData (`multipart/form-data`)
+  - Formulario codificado en URL (URL encoded form) (`application/x-www-form-urlencoded`)
+- Envío de formularios HTML como JSON.
+- Transformación automática de datos JSON
+- Capturas de progreso para navegadores y node.js con información adicional (velocidad, tiempo restante)
+- Establecimiento de límites de ancho de banda para node.js.
+- Compatible con FormData y Blob conforme a las especificaciones (incluyendo node.js).
 - Soporte para proteger al cliente contra [XSRF](http://en.wikipedia.org/wiki/Cross-site_request_forgery)
 
 # Instalación

--- a/posts/es/multipart.md
+++ b/posts/es/multipart.md
@@ -1,0 +1,189 @@
+---
+title: "Cuerpos multiparte (Multipart)"
+prev_title: "Cuerpos de solicitud codificados como URL"
+prev_link: "/docs/urlencoded"
+next_title: "Notas"
+next_link: "/docs/notes"
+---
+
+## Enviando data como `multipart/form-data`
+
+### Usando la API FormData
+
+#### Navegador
+
+```js
+const form = new FormData();
+form.append("my_field", "my value");
+form.append("my_buffer", new Blob([1, 2, 3]));
+form.append("my_file", fileInput.files[0]);
+
+axios.post("https://example.com", form);
+```
+
+Se puede conseguir el mismo resultado utilizando el serializador interno de Axios y su correspondiente método abreviado:
+
+```js
+axios.postForm("https://httpbin.org/post", {
+  my_field: "my value",
+  my_buffer: new Blob([1, 2, 3]),
+  my_file: fileInput.files, // La lista de archivos se desplegará como campos separados
+});
+```
+
+Los formularios HTML pueden ser incluidos en el payload de la petición
+
+#### Node.js
+
+```js
+import axios from "axios";
+
+const form = new FormData();
+form.append("my_field", "my value");
+form.append("my_buffer", new Blob(["some content"]));
+
+axios.post("https://example.com", form);
+```
+
+Dado que node.js no soporta la creación de un `Blob` a partir de un archivo, puedes usar software de terceros para realizar esa tarea.
+
+```js
+import {fileFromPath} from "formdata-node/file-from-path";
+
+form.append("my_field", "my value");
+form.append("my_file", await fileFromPath("/foo/bar.jpg"));
+
+axios.post("https://example.com", form);
+```
+
+Para versiones de Axios anteriores a `v1.3.0`, debes importar el paquete `form-data`
+
+```js
+const FormData = require("form-data");
+
+const form = new FormData();
+form.append("my_field", "my value");
+form.append("my_buffer", new Buffer(10));
+form.append("my_file", fs.createReadStream("/foo/bar.jpg"));
+
+axios.post("https://example.com", form);
+```
+
+### 🆕 Serialización automática
+
+A partir de la versión `v0.27.0`, Axios soporta la serialización automática de objetos
+a un objecto FormData si establecemos la cabecera Content-Type de la petición a `multipart/form-data`.
+
+La siguiente petición enviará data en formato FormData (Navegador & Node,js):
+
+```js
+import axios from "axios";
+
+axios
+  .post(
+    "https://httpbin.org/post",
+    {
+      user: {
+        name: "Dmitriy",
+      },
+      file: fs.createReadStream("/foo/bar.jpg"),
+    },
+    {
+      headers: {
+        "Content-Type": "multipart/form-data",
+      },
+    }
+  )
+  .then(({data}) => console.log(data));
+```
+
+El serializador de FormData de Axios admite algunos finales especiales para realizar las siguientes operaciones:
+
+`{}` - serializa el valor con JSON.stringify
+`[]` - desglosa el objeto similar a un array en campos separados con la misma llave (key)
+
+> NOTA:
+> La operación de desglose/expansión se utilizará de forma predeterminada en arrays y objetos FileList.
+
+El serializador de FormData admite opciones adicionales a través de la propiedad `config.formSerializer: object`
+para manejar casos inusuales:
+
+- `visitor: Function` - función de visita definida por el usuario que se llamará recursivamente para serializar el objeto de datos
+  a un objeto `FormData` siguiendo reglas personalizadas.
+
+- `dots: boolean = false` - utiliza la notación de punto en lugar de corchetes para serializar arrays y objetos;
+
+- `metaTokens: boolean = true` - agrega el final especial (por ejemplo, `user{}: '{"name": "John"}'`) en la llave (key) de FormData.
+  El body-parser del backend podría potencialmente utilizar esta meta-información para analizar automáticamente el valor como JSON.
+
+- `indexes: null|false|true = false` - controla cómo se agregarán índices a las llaves desglosadas (unwrapped keys) de objetos similares a arrays `flat`
+
+  - `null` - no agregar corchetes (`arr: 1`, `arr: 2`, `arr: 3`)
+  - `false` (predeterminado) - agregar corchetes vacíos (`arr[]: 1`, `arr[]: 2`, `arr[]: 3`)
+  - `true` - agregar corchetes con índices (`arr[0]: 1`, `arr[1]: 2`, `arr[2]: 3`)
+
+Digamos que tenemos un objeto como el siguiente:
+
+```js
+const obj = {
+  x: 1,
+  arr: [1, 2, 3],
+  arr2: [1, [2], 3],
+  users: [
+    {name: "Peter", surname: "Griffin"},
+    {name: "Thomas", surname: "Anderson"},
+  ],
+  "obj2{}": [{x: 1}],
+};
+```
+
+El serializador de Axios ejecutará internamente los siguientes pasos:
+
+```js
+const formData = new FormData();
+formData.append("x", "1");
+formData.append("arr[]", "1");
+formData.append("arr[]", "2");
+formData.append("arr[]", "3");
+formData.append("arr2[0]", "1");
+formData.append("arr2[1][0]", "2");
+formData.append("arr2[2]", "3");
+formData.append("users[0][name]", "Peter");
+formData.append("users[0][surname]", "Griffin");
+formData.append("users[1][name]", "Thomas");
+formData.append("users[1][surname]", "Anderson");
+formData.append("obj2{}", '[{"x":1}]');
+```
+
+```js
+import axios from "axios";
+
+axios
+  .post(
+    "https://httpbin.org/post",
+    {
+      "myObj{}": {x: 1, s: "foo"},
+      "files[]": document.querySelector("#fileInput").files,
+    },
+    {
+      headers: {
+        "Content-Type": "multipart/form-data",
+      },
+    }
+  )
+  .then(({data}) => console.log(data));
+```
+
+Axios soporta los siguientes métodos abreviados: `postForm`, `putForm`, `patchForm`
+que son los métodos HTTP correspondientes con la cabecera content-type predefinida como `multipart/form-data`.
+
+El objeto `FileList` puede ser pasado directamente:
+
+```js
+await axios.postForm(
+  "https://httpbin.org/post",
+  document.querySelector("#fileInput").files
+);
+```
+
+Todos los archivos se enviarán con campos del mismo nombre: `files[]`

--- a/posts/es/notes.md
+++ b/posts/es/notes.md
@@ -7,12 +7,12 @@ prev_link: "/es/docs/urlencoded"
 
 ## Semver
 
-Hasta que axios alcance una version `1.0`, cambios significativos seran liberados con una nueva versión menor. Por ejemplo `0.5.1`, y `0.5.4` tendran la misma API, pero `0.6.0` tendra cambios mayores.
+Hasta que axios alcance una version `1.0`, los cambios significativos serán liberados con una nueva versión menor. Por ejemplo `0.5.1`, y `0.5.4` tendrán la misma API, pero `0.6.0` tendrá cambios mayores.
 
 ## Promesas
 
-Axios depende de una impletación nativa de las Promesas de ES6 [verificar soporte](http://caniuse.com/promises).
-Si tu ambiente no soporta las Promesas de ES6, puedes usar [polyfill](https://github.com/jakearchibald/es6-promise).
+Axios depende de una implementación nativa de las Promesas de ES6 [verificar soporte](http://caniuse.com/promises).
+Si tu entorno no soporta las Promesas de ES6, puedes usar [polyfill](https://github.com/jakearchibald/es6-promise).
 
 ## TypeScript
 
@@ -33,7 +33,7 @@ axios.get("/user?ID=12345");
 
 ## Créditos
 
-Axios está fuertemente inspirado por el [servicio $http](https://docs.angularjs.org/api/ng/service/$http) provisto en [Angular](https://angularjs.org/). Finalmente axios es un esfuerzo para proveer de una versión independiente del servicio `$http` fuera de Angular.
+Axios está fuertemente inspirado por el [servicio $http](https://docs.angularjs.org/api/ng/service/$http) provisto en [Angular](https://angularjs.org/). En definitiva, axios es un esfuerzo para proveer una versión independiente del servicio `$http` fuera de Angular.
 
 ## Licencia
 

--- a/posts/es/post_example.md
+++ b/posts/es/post_example.md
@@ -1,18 +1,19 @@
 ---
-title: 'Peticion POST'
-description: 'Como ejecutar una peticion POST con Axios'
-prev_title: 'Ejemplo Mínimo'
-prev_link: '/es/docs/example'
-next_title: 'Axios API'
-next_link: '/es/docs/api_intro'
+title: "Peticion POST"
+description: "Como ejecutar una peticion POST con Axios"
+prev_title: "Ejemplo Mínimo"
+prev_link: "/es/docs/example"
+next_title: "Axios API"
+next_link: "/es/docs/api_intro"
 ---
 
-Ejecutando una peticion `POST`
+## Ejecutando una peticion `POST`
 
 ```js
-axios.post('/user', {
-    firstName: 'Fred',
-    lastName: 'Flintstone'
+axios
+  .post("/user", {
+    firstName: "Fred",
+    lastName: "Flintstone",
   })
   .then(function (response) {
     console.log(response);
@@ -26,16 +27,15 @@ Ejecutando múltiples peticiones concurrentes
 
 ```js
 function getUserAccount() {
-  return axios.get('/user/12345');
+  return axios.get("/user/12345");
 }
 
 function getUserPermissions() {
-  return axios.get('/user/12345/permissions');
+  return axios.get("/user/12345/permissions");
 }
 
-Promise.all([getUserAccount(), getUserPermissions()])
-  .then(function (results) {
-    const acct = results[0];
-    const perm = results[1];
-  });
+Promise.all([getUserAccount(), getUserPermissions()]).then(function (results) {
+  const acct = results[0];
+  const perm = results[1];
+});
 ```

--- a/posts/es/req_config.md
+++ b/posts/es/req_config.md
@@ -1,30 +1,29 @@
 ---
-title: 'Configuración de Petición'
-prev_title: 'La Instancia Axios'
-prev_link: '/es/docs/instance'
-next_title: 'Esquema de Respuesta'
-next_link: '/es/docs/res_schema'
+title: "Configuración de Petición"
+prev_title: "La Instancia Axios"
+prev_link: "/es/docs/instance"
+next_title: "Esquema de Respuesta"
+next_link: "/es/docs/res_schema"
 ---
 
-
-Estas son las opciones de configuración disponibles para hacer peticiones. Solo el `url` es requerido. Las peticiones serán por defecto `GET` si `method` no es especificado.
+Estas son las opciones de configuración disponibles para hacer peticiones. Sólo el `url` es requerido. Las peticiones serán por defecto `GET` si `method` no es especificado.
 
 ```js
 {
-  // `url` es la URL del servidor que sera usada para la petición
+  // `url` es la URL del servidor que será usada para la petición
   url: '/user',
 
-  // `method` es el método a ser utilizado al hacer la petición 
-  method: 'get', // defecto
+  // `method` es el método a ser utilizado al hacer la petición
+  method: 'get', // por defecto
 
-  // `baseURL` será precedido a `url` a no ser que `url` sea absoluto.
+  // `baseURL` será precedido a `url` a menos que `url` sea absoluto.
   // Es conveniente establecer un `baseURL` en una instancia de axios para pasar URLs relativas
-  // a los métodos de esta
+  // a los métodos de ésta
   baseURL: 'https://some-domain.com/api',
 
   // `transformRequest` permite cambios al data de la petición antes de ser enviado al servidor
-  // Esto es solo aplicable para los métodos de petición 'PUT', 'POST', 'PATCH' y 'DELETE'
-  // La última función en el arreglo debe regresar un string o una instancia de Buffer, ArrayBuffer,
+  // Esto es sólo aplicable para los métodos de petición 'PUT', 'POST', 'PATCH' y 'DELETE'
+  // La última función de la colección (array) debe retornar un string o una instancia de Buffer, ArrayBuffer,
   // FormData o Stream
   // Debes modificar el objeto headers.
   transformRequest: [function (data, headers) {
@@ -51,45 +50,45 @@ Estas son las opciones de configuración disponibles para hacer peticiones. Solo
     ID: 12345
   },
 
-  // `paramsSerializer` es una funcion opcional a cargo de serializar `params`
-  // (e.g. https://www.npmjs.com/package/qs, http://api.jquery.com/jquery.param/)
+  // `paramsSerializer` es una función opcional a cargo de serializar `params`
+  // (por ejemplo, https://www.npmjs.com/package/qs, http://api.jquery.com/jquery.param/)
   paramsSerializer: function (params) {
     return Qs.stringify(params, {arrayFormat: 'brackets'})
   },
 
-  // `data` es el data a ser enviado como el cuerpo de la petición
-  // Solo aplicable a los métodos de petición 'PUT', 'POST', 'DELETE , y 'PATCH'
+  // `data` es el data a ser enviado como el cuerpo (body) de la petición
+  // Sólo aplicable a los métodos de petición 'PUT', 'POST', 'DELETE , y 'PATCH'
   // Cuando no se establece `transformRequest`, debe ser uno de los siguientes tipos:
   // - string, plain object, ArrayBuffer, ArrayBufferView, URLSearchParams
-  // - Solo Navegador: FormData, File, Blob
-  // - Solo en Node: Stream, Buffer
+  // - Sólo Navegador: FormData, File, Blob
+  // - Sólo en Node: Stream, Buffer
   data: {
     firstName: 'Fred'
   },
-  
+
   // sintaxis alternativa para enviar data al cuerpo
   // del método post
-  // solo el valor es enviando, no la llave
+  // sólo el valor es enviando, no la llave
   data: 'Country=Brasil&City=Belo Horizonte',
 
   // `timeout` especifica el número de milisegundos antes que la petición expire.
-  // Si la petición toma más tiempo que `timeout`, esta será abortada.
-  timeout: 1000, // `0` es el valor por defecto (no timeout)
+  // Si la petición toma más tiempo que `timeout`, ésta será abortada.
+  timeout: 1000, // `0` es el valor por defecto (sin timeout)
 
-  // `withCredentials` indica cuando o no se pueden hacer peticiones cross-site Access-Control 
-  // usando credenciales
-  withCredentials: false, // defecto
+  // `withCredentials` indica si las solicitudes de acceso entre sitios (cross-site)
+  // deben realizarse utilizando credenciales
+  withCredentials: false, // por defecto
 
-  // `adapter` permite la manipulación personalizada de peticiones, haciendo las pruebas más fácil.
-  // Retorna una promesa y provee una respuesta valida (ver lib/adapters/README.md).
+  // `adapter` permite la manipulación personalizada de peticiones, facilitando la realización de pruebas y testeos.
+  // Retorna una promesa y provee una respuesta válida (ver lib/adapters/README.md).
   adapter: function (config) {
     /* ... */
   },
 
-  // `auth` indica que HTTP Basic auth debe ser usado, y proveer credenciales.
+  // `auth` indica que HTTP Basic auth debe ser usado y provee credenciales.
   // Esto establecerá una cabecera `Authorization`, sobrescribiendo cualquier cabecera personalizada
-  // existente `Authorization`, previamente a través de `headers`.
-  // Ten encuenta que solo HTTP Basic auth es configurable a través de este parámetro.
+  // existente `Authorization`, previamente establecida a través de `headers`.
+  // Ten en cuenta que sólo HTTP Basic auth es configurable a través de este parámetro.
   // Para tokens Bearer y otros, usa la cabecera personalizada `Authorization` en su lugar.
   auth: {
     username: 'janedoe',
@@ -98,27 +97,27 @@ Estas son las opciones de configuración disponibles para hacer peticiones. Solo
 
   // `responseType` indica el tipo de data con el que el servidor responderá
   // las opciones son: 'arraybuffer', 'document', 'json', 'text', 'stream'
-  // solo en el navegador: 'blob'
-  responseType: 'json', // defecto
-  
-  // `responseEncoding` indica la codificación a usar para decodificar las respuestas (solo en Node.js)
+  // sólo en el navegador: 'blob'
+  responseType: 'json', // por defecto
+
+  // `responseEncoding` indica la codificación a usar para decodificar las respuestas (sólo en Node.js)
   // Nota: Ignorado para `responseType` de 'stream' o peticiones del lado del cliente
-  responseEncoding: 'utf8', // defecto
+  responseEncoding: 'utf8', // por defecto
 
   // `xsrfCookieName` es el nombre de la cookie a usar como valor para el token xsrf
-  xsrfCookieName: 'XSRF-TOKEN', // defecto
+  xsrfCookieName: 'XSRF-TOKEN', // por defecto
 
   // `xsrfHeaderName` es el nombre de la cabecera http que lleva el valor del token xsrf
-  xsrfHeaderName: 'X-XSRF-TOKEN', // defecto
+  xsrfHeaderName: 'X-XSRF-TOKEN', // por defecto
 
   // `onUploadProgress` permite la manipulación del evento progress para subidas
-  // solo en el navegador
+  // sólo en el navegador
   onUploadProgress: function (progressEvent) {
     // Haz lo que quieras con el evento nativo progress
   },
 
-  // `onDownloadProgress` permite la manipulación del evento progress para descargars
-  // solo en el navegador
+  // `onDownloadProgress` permite la manipulación del evento progress para descargas
+  // sólo en el navegador
   onDownloadProgress: function (progressEvent) {
     // Haz lo que quieras con el evento nativo progress
   },
@@ -126,11 +125,11 @@ Estas son las opciones de configuración disponibles para hacer peticiones. Solo
   // `maxContentLength` define el tamaño máximo del contenido de la respuesta http en bytes permitidos en node.js
   maxContentLength: 2000,
 
-  // `maxBodyLength` (opcion solo para Node) define el tamaño máximo permitido del contenido de la petición http en bytes
+  // `maxBodyLength` (opción solo para Node) define el tamaño máximo permitido del contenido de la petición http en bytes
   maxBodyLength: 2000,
 
   // `validateStatus` define si resolver o rechazar la promesa para un dado
-  // codigo de respuesta HTTP. Si `validateStatus` retorna `true` (o si se establece a `null`
+  // código de respuesta HTTP. Si `validateStatus` retorna `true` (o si se establece a `null`
   // o `undefined`), la promesa será resuelta; de otra manera, la promesa será
   // rechazada.
   validateStatus: function (status) {
@@ -138,32 +137,32 @@ Estas son las opciones de configuración disponibles para hacer peticiones. Solo
   },
 
   // `maxRedirects` define el número máximo de redirecciones a seguir en node.js.
-  // Si se establece en 0, no habra redirecciones.
-  maxRedirects: 5, // defecto
+  // Si se establece en 0, no habrá redirecciones.
+  maxRedirects: 5, // por defecto
 
   // `socketPath` define un Socket UNIX a ser utilizado en node.js.
-  // e.g. '/var/run/docker.sock' para enviar peticiones al demonio de docker (docker daemon).
-  // Solo `socketPath` o `proxy` puede ser especificado.
+  // por ejemplo, '/var/run/docker.sock' para enviar peticiones al daemon de docker (docker daemon).
+  // Sólo `socketPath` o `proxy` puede ser especificado.
   // Si ambos son especificados, `socketPath` es utilizado.
-  socketPath: null, // defecto
+  socketPath: null, // por defecto
 
   // `httpAgent` y `httpsAgent` definen un agente personalizado a ser usado al realizar una petición
   // http y https, respectivamente, en node.js. Esto permite añadir opciones como
-  // `keepAlive` que no estan habilitadas por defecto.
+  // `keepAlive` que no están habilitadas por defecto.
   httpAgent: new http.Agent({ keepAlive: true }),
   httpsAgent: new https.Agent({ keepAlive: true }),
 
   // `proxy` define hostname, puerto, y protocolo del servidor proxy.
-  // También puedes definir tu proxy usando las variables de entorno convencionales 
-  // `http_proxy` y `https_proxy`. Si estas usando variables de entorno
+  // También puedes definir tu proxy usando las variables de entorno convencionales
+  // `http_proxy` y `https_proxy`. Si estás usando variables de entorno
   // para tu configuración proxy, también puedes definir una variable de entorno `no_proxy`
   // como una lista separada por comas de dominios que no deben ser tomados en cuenta (proxied).
   // Usa `false` para desabilitar los proxies, ignorando las variables de entorno.
   // `auth` indica que HTTP Basic auth debe ser usado para conectar al proxy, y
-  // proveer credenciales.
+  // provee credenciales.
   // Esto establecerá una cabecera `Proxy-Authorization`, sobrescribiendo cualquier cabecera personalizada
   // existente `Proxy-Authorization` establecidas por `headers`.
-  // Si el servidor proxy usa HTTPS, entonces debes establecer el protocolo a `https`. 
+  // Si el servidor proxy usa HTTPS, entonces debes establecer el protocolo a `https`.
   proxy: {
     protocol: 'https',
     host: '127.0.0.1',
@@ -179,11 +178,11 @@ Estas son las opciones de configuración disponibles para hacer peticiones. Solo
   cancelToken: new CancelToken(function (cancel) {
   }),
 
-  // `decompress` indica sí o no el cuerpo de la respuesta debe ser descomprimido 
-  // automáticamente. Si se establece en `true` también removerá la cabecera 'content-encoding'  
+  // `decompress` indica si el cuerpo de la respuesta debe ser descomprimido
+  // automáticamente. Si se establece en `true` también eliminará la cabecera 'content-encoding'
   // de los objetos de respuesta de todas las respuestas descomprimidas
-  // - solo en Node (XHR no puede apagar la descompresión)
-  decompress: true // defecto
+  // - sólo en Node (XHR no puede apagar la descompresión)
+  decompress: true // por defecto
 
 }
 ```

--- a/posts/es/res_schema.md
+++ b/posts/es/res_schema.md
@@ -1,16 +1,16 @@
 ---
-title: 'Esquema de Respuesta'
-prev_title: 'Configuración de Petición'
-prev_link: '/es/docs/req_config'
-next_title: 'Configuraciones por Defecto'
-next_link: '/es/docs/config_defaults'
+title: "Esquema de Respuesta"
+prev_title: "Configuración de Petición"
+prev_link: "/es/docs/req_config"
+next_title: "Configuraciones por Defecto"
+next_link: "/es/docs/config_defaults"
 ---
 
 La respuesta para una petición contiene la siguiente información.
 
 ```js
 {
-  // `data` es la respuesta provista por el servidor
+  // `data` es la respuesta proporcionada por el servidor
   data: {},
 
   // `status` es el código HTTP de la respuesta del servidor
@@ -24,11 +24,11 @@ La respuesta para una petición contiene la siguiente información.
   // Ejemplo: `response.headers['content-type']`
   headers: {},
 
-  // `config`  es la configuración provista a `axios` por la petición
+  // `config` es la configuración provista a `axios` para la petición
   config: {},
 
-  // `request` es la petición que genera esta respuesta,
-  // es la última instancia ClientRequest en node.js (en redirecciones)
+  // `request` es la petición que genera esta respuesta
+  // Es la última instancia ClientRequest en node.js (en redirecciones)
   // y una instancia XMLHttpRequest en el navegador.
   request: {}
 }
@@ -37,14 +37,13 @@ La respuesta para una petición contiene la siguiente información.
 Al usar `then`, recibirás la respuesta de la siguiente manera:
 
 ```js
-axios.get('/user/12345')
-  .then(function (response) {
-    console.log(response.data);
-    console.log(response.status);
-    console.log(response.statusText);
-    console.log(response.headers);
-    console.log(response.config);
-  });
+axios.get("/user/12345").then(function (response) {
+  console.log(response.data);
+  console.log(response.status);
+  console.log(response.statusText);
+  console.log(response.headers);
+  console.log(response.config);
+});
 ```
 
 Al usar `catch`, o pasando un [rejection callback](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/then) como segundo parámetro de `then`, la respuesta estará disponible a través del objeto `error` como se explicó en la sección [Manipulando errores](/es/docs/handling_errors).

--- a/posts/es/translating.md
+++ b/posts/es/translating.md
@@ -13,22 +13,22 @@ de archivos de documentación traducidos en `posts/{language-shortcut}/*.md` (po
 ## Configurando tu idioma
 
 - Copia `en.lang.js`.
-- Renombralo a `{language-shortcut}.lang.js`.
-- Reemplaza `display` con el nombre de tu idioma, en tu idioma. Por ejemplo, si estas traduciendo al alemán, usa “Deutsch” en vez de “Alemán”.
+- Renómbralo a `{language-shortcut}.lang.js`.
+- Reemplaza `display` con el nombre de tu idioma, en tu idioma. Por ejemplo, si estás traduciendo al alemán, usa “Deutsch” en lugar de “Alemán”.
 - Reemplaza el prefijo con `/{language-shortcut}/`.
 - Traduce los valores en los campos `p` y `t`.
-- Traduce todas las propiedades de nombre `text` en sidebar. **Nota:** Desde la última versión de esta documentación, los links en el sidebar no necesitan ser traducidos.
+- Traduce todas las propiedades de nombre `text` en el sidebar. **Nota:** Desde la última versión de esta documentación, los links en el sidebar no necesitan ser traducidos.
 
 ### Registrando la configuración
 
-Una vez que has finalizado de configurar tu idioma y traducido las frases y enlaces en el archivo de configuración, necesitaras registrarlo
+Una vez que has finalizado de configurar tu idioma y traducido las frases y enlaces en el archivo de configuración, necesitarás registrarlo
 en la configuración principal. Para hacerlo, abre `inert.config.js` y agrega lo siguiente en la parte de arriba:
 
 ```js
 const {language-shortcut}Config = require('./{language-shortcut}.config.js');
 ```
 
-Claro, recuerda reemplazar `{language-shortcut}` con el código correcto [ISO 369-1](https://en.wikipedia.org/wiki/ISO_639-1) (en el nombre de la variable, !tambien!).
+Claro, recuerda reemplazar `{language-shortcut}` con el código correcto [ISO 369-1](https://en.wikipedia.org/wiki/ISO_639-1) (¡En el nombre de la variable también!).
 
 Ahora, busca la constante `langs`. Si la constante esta por encima de tu declaración `require`, mueve tu declaración `require` arriba. En la lista `langs`, agrega el siguiente objecto:
 

--- a/posts/es/urlencoded.md
+++ b/posts/es/urlencoded.md
@@ -1,12 +1,12 @@
 ---
-title: 'Cuerpos de solicitud codificados como URL'
-prev_title: 'Cancelación'
-prev_link: '/es/docs/cancellation'
-next_title: 'Notas'
-next_link: '/es/docs/notes'
+title: "Cuerpos de solicitud codificados como URL"
+prev_title: "Cancelación"
+prev_link: "/es/docs/cancellation"
+next_title: "Notas"
+next_link: "/es/docs/notes"
 ---
 
-Por defecto, axios serializa objetos JavaScript a `JSON`. Para enviar data en un formato distinto a `application/x-www-form-urlencoded`, puedes usar una de las siguientes opciones.
+Por defecto, axios serializa objetos JavaScript a `JSON`. En su lugar, para enviar data en formato `application/x-www-form-urlencoded`, puedes usar una de las siguientes opciones.
 
 ### Navegador
 
@@ -14,28 +14,28 @@ En un navegador, puedes usar el API [`URLSearchParams`](https://developer.mozill
 
 ```js
 const params = new URLSearchParams();
-params.append('param1', 'value1');
-params.append('param2', 'value2');
-axios.post('/foo', params);
+params.append("param1", "value1");
+params.append("param2", "value2");
+axios.post("/foo", params);
 ```
 
-> Nota que `URLSearchParams` no es soportado por todos los navegadores (ver [caniuse.com](http://www.caniuse.com/#feat=urlsearchparams)), pero hay un [polyfill](https://github.com/WebReflection/url-search-params) disponible (asegurate de usar polyfill en el ambiente global).
+> Nota que `URLSearchParams` no es soportado por todos los navegadores (ver [caniuse.com](http://www.caniuse.com/#feat=urlsearchparams)), pero hay un [polyfill](https://github.com/WebReflection/url-search-params) disponible (asegúrate de usar polyfill en el ambiente global).
 
 Alternativamente, puedes codificar data usando la librería [`qs`](https://github.com/ljharb/qs):
 
 ```js
-const qs = require('qs');
-axios.post('/foo', qs.stringify({ 'bar': 123 }));
+const qs = require("qs");
+axios.post("/foo", qs.stringify({bar: 123}));
 ```
 
 O de otra manera (ES6),
 
 ```js
-import qs from 'qs';
-const data = { 'bar': 123 };
+import qs from "qs";
+const data = {bar: 123};
 const options = {
-  method: 'POST',
-  headers: { 'content-type': 'application/x-www-form-urlencoded' },
+  method: "POST",
+  headers: {"content-type": "application/x-www-form-urlencoded"},
   data: qs.stringify(data),
   url,
 };
@@ -46,24 +46,25 @@ axios(options);
 
 #### Query string
 
-En node.js, puedes usar el modulo [`querystring`](https://nodejs.org/api/querystring.html) de la siguiente manera:
+En node.js, puedes usar el módulo [`querystring`](https://nodejs.org/api/querystring.html) de la siguiente manera:
 
 ```js
-const querystring = require('querystring');
-axios.post('http://something.com/', querystring.stringify({ foo: 'bar' }));
+const querystring = require("querystring");
+axios.post("http://something.com/", querystring.stringify({foo: "bar"}));
 ```
 
 O ['URLSearchParams'](https://nodejs.org/api/url.html#url_class_urlsearchparams) del ['modulo url'](https://nodejs.org/api/url.html) de esta manera:
 
 ```js
-const url = require('url');
-const params = new url.URLSearchParams({ foo: 'bar' });
-axios.post('http://something.com/', params.toString());
+const url = require("url");
+const params = new url.URLSearchParams({foo: "bar"});
+axios.post("http://something.com/", params.toString());
 ```
 
 También puedes usar la librería [`qs`](https://github.com/ljharb/qs).
 
 ###### NOTA
+
 La librería `qs` es preferida si necesitas un stringify de objetos anidados, ya que el método `querystring` tiene problemas conocidos con ese caso de uso (https://github.com/nodejs/node-v0.x-archive/issues/1665).
 
 #### Form data
@@ -71,20 +72,20 @@ La librería `qs` es preferida si necesitas un stringify de objetos anidados, ya
 En node.js, puedes usar la librería [`form-data`](https://github.com/form-data/form-data) de la siguiente manera:
 
 ```js
-const FormData = require('form-data');
- 
-const form = new FormData();
-form.append('my_field', 'my value');
-form.append('my_buffer', new Buffer(10));
-form.append('my_file', fs.createReadStream('/foo/bar.jpg'));
+const FormData = require("form-data");
 
-axios.post('https://example.com', form, { headers: form.getHeaders() })
+const form = new FormData();
+form.append("my_field", "my value");
+form.append("my_buffer", new Buffer(10));
+form.append("my_file", fs.createReadStream("/foo/bar.jpg"));
+
+axios.post("https://example.com", form, {headers: form.getHeaders()});
 ```
 
 Alternativamente, usa un interceptor:
 
 ```js
-axios.interceptors.request.use(config => {
+axios.interceptors.request.use((config) => {
   if (config.data instanceof FormData) {
     Object.assign(config.headers, config.data.getHeaders());
   }


### PR DESCRIPTION
- Corrected typos.

- Restructured text and code snippets to align more closely with the English documentation. 

- Added clarifications using english terms, as most spanish-speaking developers will benefit from reading the actual english terminology that will be shown to them while working with axios

- Included the missing "multipart.md" page in the Spanish documentation, mirroring the content available in the English version.
