### PR TITLE
Fix typo in Japanese

### DIFF
--- a/ja.lang.js
+++ b/ja.lang.js
@@ -39,12 +39,12 @@ module.exports = {
   sidebar: [
     {
       type: "heading",
-      text: "Axiom 入門",
+      text: "Axios 入門",
     },
     {
       type: "link",
       href: "/docs/intro",
-      text: "Axiom 入門",
+      text: "Axios 入門",
     },
     {
       type: "link",

--- a/posts/ja/intro.md
+++ b/posts/ja/intro.md
@@ -1,5 +1,5 @@
 ---
-title: 'Axiom 入門'
+title: 'Axios 入門'
 description: 'ブラウザと Node.js のための Promise ベースの HTTP クライアント'
 next_title: '最小構成の使用例'
 next_link: '/docs/example'


### PR DESCRIPTION
`Axiom` => `Axios`