### PR TITLE
style: make ‘axios’ word’s highlighting consistent

### DIFF
--- a/posts/en/cancellation.md
+++ b/posts/en/cancellation.md
@@ -8,11 +8,11 @@ next_link: '/docs/urlencoded'
 
 ## Cancelling requests
 
-Setting the `timeout` property in an axios call handles **response** related timeouts. 
+Setting the `timeout` property in an `axios` call handles **response** related timeouts.
 
-In some cases (e.g. network connection becomes unavailable) an axios call would benefit from cancelling the **connection** early. Without cancellation, the axios call can hang until the parent code/stack times out (might be a few minutes in a server-side applications). 
+In some cases (e.g. network connection becomes unavailable) an `axios` call would benefit from cancelling the **connection** early. Without cancellation, the `axios` call can hang until the parent code/stack times out (might be a few minutes in a server-side applications).
 
-To terminate an axios call you can use following methods:
+To terminate an `axios` call you can use following methods:
 - `signal`
 - `cancelToken` (deprecated)
 
@@ -61,9 +61,9 @@ axios.get('/foo/bar', {
 
 ### CancelToken `deprecated`
 
-You can also cancel a request using a *CancelToken*. 
+You can also cancel a request using a *CancelToken*.
 
-> The axios cancel token API is based on the withdrawn [cancelable promises proposal](https://github.com/tc39/proposal-cancelable-promises).
+> The `axios` cancel token API is based on the withdrawn [cancelable promises proposal](https://github.com/tc39/proposal-cancelable-promises).
 
 > This API is deprecated since `v0.22.0` and shouldn't be used in new projects
 

--- a/posts/en/config_defaults.md
+++ b/posts/en/config_defaults.md
@@ -10,7 +10,7 @@ next_link: '/docs/interceptors'
 
 You can specify config defaults that will be applied to every request.
 
-### Global axios defaults
+### Global `axios` defaults
 
 ```js
 axios.defaults.baseURL = 'https://api.example.com';

--- a/posts/en/instance.md
+++ b/posts/en/instance.md
@@ -8,7 +8,7 @@ next_link: '/docs/req_config'
 
 ### Creating an instance
 
-You can create a new instance of axios with a custom config.
+You can create a new instance of `axios` with a custom config.
 
 ##### axios.create([config])
 

--- a/posts/en/interceptors.md
+++ b/posts/en/interceptors.md
@@ -37,7 +37,7 @@ const myInterceptor = axios.interceptors.request.use(function () {/*...*/});
 axios.interceptors.request.eject(myInterceptor);
 ```
 
-You can add interceptors to a custom instance of axios.
+You can add interceptors to a custom instance of `axios`.
 
 ```js
 const instance = axios.create();

--- a/posts/en/notes.md
+++ b/posts/en/notes.md
@@ -7,15 +7,15 @@ prev_link: '/docs/urlencoded'
 
 ## Semver
 
-Until axios reaches a `1.0` release, breaking changes will be released with a new minor version. For example `0.5.1`, and `0.5.4` will have the same API, but `0.6.0` will have breaking changes.
+Until `axios` reaches a `1.0` release, breaking changes will be released with a new minor version. For example `0.5.1`, and `0.5.4` will have the same API, but `0.6.0` will have breaking changes.
 
 ## Promises
 
-axios depends on a native ES6 Promise implementation to be [supported](http://caniuse.com/promises).
+`axios` depends on a native ES6 Promise implementation to be [supported](http://caniuse.com/promises).
 If your environment doesn't support ES6 Promises, you can [polyfill](https://github.com/jakearchibald/es6-promise).
 
 ## TypeScript
-axios includes [TypeScript](http://typescriptlang.org) definitions.
+`axios` includes [TypeScript](http://typescriptlang.org) definitions.
 ```typescript
 import axios from 'axios';
 axios.get('/user?ID=12345');
@@ -31,7 +31,7 @@ axios.get('/user?ID=12345');
 
 ## Credits
 
-axios is heavily inspired by the [$http service](https://docs.angularjs.org/api/ng/service/$http) provided in [Angular](https://angularjs.org/). Ultimately axios is an effort to provide a standalone `$http`-like service for use outside of Angular.
+`axios` is heavily inspired by the [$http service](https://docs.angularjs.org/api/ng/service/$http) provided in [Angular](https://angularjs.org/). Ultimately axios is an effort to provide a standalone `$http`-like service for use outside of Angular.
 
 ## License
 

--- a/posts/en/urlencoded.md
+++ b/posts/en/urlencoded.md
@@ -6,7 +6,7 @@ next_title: 'Multipart Bodies'
 next_link: '/docs/multipart'
 ---
 
-By default, axios serializes JavaScript objects to `JSON`. To send data in the `application/x-www-form-urlencoded` format instead, you can use one of the following approaches.
+By default, `axios` serializes JavaScript objects to `JSON`. To send data in the `application/x-www-form-urlencoded` format instead, you can use one of the following approaches.
 
 ### Browser
 
@@ -84,7 +84,7 @@ await axios.post('https://postman-echo.com/post', data,
 );
 ```
 
-The server will handle it as 
+The server will handle it as
 
 ```js
   {
@@ -101,16 +101,16 @@ The server will handle it as
   }
 ````
 
-If your server framework's request body parser (like `body-parser` of `express.js`) supports nested objects decoding, 
+If your server framework's request body parser (like `body-parser` of `express.js`) supports nested objects decoding,
 you will automatically receive the same server object that you submitted.
 
 Echo server example (`express.js`) :
 
 ```js
   var app = express();
-  
+
   app.use(bodyParser.urlencoded({ extended: true })); // support url-encoded bodies
-  
+
   app.post('/', function (req, res, next) {
      res.send(JSON.stringify(req.body));
   });


### PR DESCRIPTION
i noticed `axios` isn’t always highlighted, this PR fixes it. Here’s the relevant [issue](https://github.com/axios/axios-docs/issues/189)