### PR TITLE
Added gap between hero text

### DIFF
--- a/templates/home.ejs
+++ b/templates/home.ejs
@@ -4,8 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Axios</title>
-    <link rel="stylesheet" href="/style/sponsors.css" />
-    <link rel="stylesheet" href="/style/home.css" />
+    <link rel="stylesheet" href="./style/sponsors.css" />
+    <link rel="stylesheet" href="./style/home.css" />
     <style>
       * {
         <%= locale.fontSans ? 'font-family: ' + locale.fontSans + ';' : '' %>
@@ -51,6 +51,7 @@
         ><%= locale.t['Get Started'] || 'Get Started' %></a
       >
     </header>
+    <br><br>
     <main>
       <section id="hero">
         <div class="content">


### PR DESCRIPTION
There is a small gap between the navbar and the hero main text. This was implemented using `<br>` tags. If you want an approach using css, let me know.

I have also updated the `<link>` paths to include a dot (.)

This PR closes #205