### PR TITLE
Bug Fix: Navbar Overlapping the Headline in the Hero Section

### DIFF
--- a/scss/home.scss
+++ b/scss/home.scss
@@ -72,6 +72,7 @@ section#hero {
   align-items: center;
   justify-content: space-between;
   flex-flow: row nowrap;
+  margin-top: 10rem;
 
   div.content {
     width: 100%;


### PR DESCRIPTION
### Description of the Bug  
The navbar on the landing page of `axios-http.com` was overlapping the headline in the hero section. This caused a visual issue where the content was not properly aligned and appeared cluttered.  

Fixes: #205

### Fix Implemented  
Added a `margin-top` property to the hero section to create adequate spacing between the navbar and the headline. This resolves the issue and ensures proper layout alignment.  

### Screenshots
Before Fix:  
<img width="1280" alt="Screenshot 2024-12-24 at 1 32 43 PM" src="https://github.com/user-attachments/assets/25873182-b6cf-4640-8a17-d291e0d879d6" />

After Fix:  
<img width="1280" alt="Screenshot 2024-12-24 at 1 32 35 PM" src="https://github.com/user-attachments/assets/a7493ee9-2c64-4344-a297-6a669bb83a61" />


### Testing  
- Verified the fix across multiple screen sizes to ensure responsive behavior.  
- Confirmed that the navbar no longer overlaps the headline.  

### Additional Notes  
Let me know if any further adjustments or tests are required!  