### PR TITLE
Translation typo

### DIFF
--- a/posts/en/req_config.md
+++ b/posts/en/req_config.md
@@ -183,7 +183,7 @@ These are the available config options for making requests. Only the `url` is re
   // `signal` and instance of AbortController can be used to cancel the request
   signal: new AbortController().signal,
 
-  // (Deprecatred) `cancelToken` specifies a cancel token that can also be used to cancel the request
+  // (Deprecated) `cancelToken` specifies a cancel token that can also be used to cancel the request
   // (see Cancellation section below for details)
   cancelToken: new CancelToken(function (cancel) {
   }),

--- a/posts/en/translating.md
+++ b/posts/en/translating.md
@@ -44,4 +44,4 @@ const langs = [
 
 Now, you can begin translating the files. Copy the folder `posts/en` into a new folder `posts/{language-shortcut}` and translate all the files (don't translate the filenames, of course).
 
-If you hit any problems, feel free to [create and issue](https://github.com/axios/axios-docs/issues/new/choose).
+If you hit any problems, feel free to [create an issue](https://github.com/axios/axios-docs/issues/new/choose).


### PR DESCRIPTION
Couple of typoes I found when reading through the docs. 

Doesn't materially change the docs at all other than makes searching for  "Deprecated"'s easier. 