### PR TITLE
doc(instance): instance config call example

### DIFF
--- a/posts/ar/instance.md
+++ b/posts/ar/instance.md
@@ -33,3 +33,30 @@ The available instance methods are listed below. The specified config will be me
 ##### axios#put(url[, data[, config]])
 ##### axios#patch(url[, data[, config]])
 ##### axios#getUri([config])
+
+### Calling the instance with a config object
+
+In addition to using convenience methods like `instance.get()` or `instance.post()`, you can also call an Axios instance directly with a config object. This is functionally equivalent to `axios(config)`, and is particularly useful when retrying a request using the original configuration.
+
+```js
+const instance = axios.create({ baseURL: '/api' });
+
+// Works just like axios(config)
+instance({
+  url: '/users',
+  method: 'get'
+});
+```
+
+This approach enables clean retry logic when handling authentication errors:
+
+```js
+instance.interceptors.response.use(undefined, async (error) => {
+  if (error.response?.status === 401) {
+    await refreshToken();
+    return instance(error.config); // Retry original request
+  }
+
+  throw error;
+});
+```

--- a/posts/de/instance.md
+++ b/posts/de/instance.md
@@ -33,3 +33,30 @@ Die verfügbaren Instanzmethoden sind im folgenden aufgelistet. Die beim Aufruf 
 ##### axios#put(url[, data[, config]])
 ##### axios#patch(url[, data[, config]])
 ##### axios#getUri([config])
+
+### Instanz direkt mit einem Konfigurationsobjekt aufrufen
+
+Neben den Komfortmethoden wie `instance.get()` oder `instance.post()` können Sie eine Axios-Instanz auch direkt mit einem Konfigurationsobjekt aufrufen. Dies funktioniert genauso wie `axios(config)` und ist besonders nützlich, wenn Sie eine Anfrage mit der ursprünglichen Konfiguration erneut senden möchten.
+
+```js
+const instance = axios.create({ baseURL: '/api' });
+
+// Funktioniert wie axios(config)
+instance({
+  url: '/users',
+  method: 'get'
+});
+```
+
+Dieses Vorgehen ermöglicht eine saubere Retry-Logik, z.B. beim Umgang mit Authentifizierungsfehlern:
+
+```js
+instance.interceptors.response.use(undefined, async (error) => {
+  if (error.response?.status === 401) {
+    await refreshToken();
+    return instance(error.config); // Ursprüngliche Anfrage erneut senden
+  }
+
+  throw error;
+});
+```

--- a/posts/en/instance.md
+++ b/posts/en/instance.md
@@ -33,3 +33,30 @@ The available instance methods are listed below. The specified config will be me
 ##### axios#put(url[, data[, config]])
 ##### axios#patch(url[, data[, config]])
 ##### axios#getUri([config])
+
+### Calling the instance with a config object
+
+In addition to using convenience methods like `instance.get()` or `instance.post()`, you can also call an Axios instance directly with a config object. This is functionally equivalent to `axios(config)`, and is particularly useful when retrying a request using the original configuration.
+
+```js
+const instance = axios.create({ baseURL: '/api' });
+
+// Works just like axios(config)
+instance({
+  url: '/users',
+  method: 'get'
+});
+```
+
+This approach enables clean retry logic when handling authentication errors:
+
+```js
+instance.interceptors.response.use(undefined, async (error) => {
+  if (error.response?.status === 401) {
+    await refreshToken();
+    return instance(error.config); // Retry original request
+  }
+
+  throw error;
+});
+```

--- a/posts/es/instance.md
+++ b/posts/es/instance.md
@@ -33,3 +33,30 @@ Los métodos disponibles de la instancia están listados a continuación. La con
 ##### axios#put(url[, data[, config]])
 ##### axios#patch(url[, data[, config]])
 ##### axios#getUri([config])
+
+### Llamar a la instancia directamente con un objeto de configuración
+
+Además de los métodos como `instance.get()` o `instance.post()`, también puedes llamar a una instancia de Axios directamente pasando un objeto de configuración. Esto funciona igual que `axios(config)` y es útil, por ejemplo, para reenviar una solicitud con la configuración original.
+
+```js
+const instance = axios.create({ baseURL: '/api' });
+
+// Funciona igual que axios(config)
+instance({
+  url: '/users',
+  method: 'get'
+});
+```
+
+Este enfoque permite implementar una lógica de reintento limpia, por ejemplo, al manejar errores de autenticación:
+
+```js
+instance.interceptors.response.use(undefined, async (error) => {
+  if (error.response?.status === 401) {
+    await refreshToken();
+    return instance(error.config); // Reenviar la solicitud original
+  }
+
+  throw error;
+});
+```

--- a/posts/fa/instance.md
+++ b/posts/fa/instance.md
@@ -33,3 +33,30 @@ const instance = axios.create({
 ##### axios#put(url[, data[, config]])
 ##### axios#patch(url[, data[, config]])
 ##### axios#getUri([config])
+
+### فراخوانی مستقیم نمونه با شیء پیکربندی
+
+علاوه بر متدهای کمکی مانند `instance.get()` یا `instance.post()`، می‌توانید یک نمونه Axios را مستقیماً با یک شیء پیکربندی فراخوانی کنید. این کار دقیقاً مانند `axios(config)` عمل می‌کند و زمانی مفید است که بخواهید یک درخواست را با پیکربندی اولیه دوباره ارسال کنید.
+
+```js
+const instance = axios.create({ baseURL: '/api' });
+
+// مشابه axios(config) عمل می‌کند
+instance({
+  url: '/users',
+  method: 'get'
+});
+```
+
+این روش امکان پیاده‌سازی منطق retry تمیز را فراهم می‌کند؛ مثلاً هنگام مدیریت خطاهای احراز هویت:
+
+```js
+instance.interceptors.response.use(undefined, async (error) => {
+  if (error.response?.status === 401) {
+    await refreshToken();
+    return instance(error.config); // ارسال مجدد درخواست اصلی
+  }
+
+  throw error;
+});
+```

--- a/posts/fr/instance.md
+++ b/posts/fr/instance.md
@@ -33,3 +33,30 @@ Les méthodes utilisables sur l’instance sont listées ci-dessous. La configur
 ##### axios#put(url[, data[, config]])
 ##### axios#patch(url[, data[, config]])
 ##### axios#getUri([config])
+
+### Appeler directement l’instance avec un objet de configuration
+
+En plus des méthodes pratiques comme `instance.get()` ou `instance.post()`, vous pouvez aussi appeler une instance Axios directement avec un objet de configuration. Cela fonctionne comme `axios(config)` et est particulièrement utile pour renvoyer une requête avec la configuration d’origine.
+
+```js
+const instance = axios.create({ baseURL: '/api' });
+
+// Fonctionne comme axios(config)
+instance({
+  url: '/users',
+  method: 'get'
+});
+```
+
+Cette approche permet une logique de retry propre, par exemple lors de la gestion des erreurs d’authentification :
+
+```js
+instance.interceptors.response.use(undefined, async (error) => {
+  if (error.response?.status === 401) {
+    await refreshToken();
+    return instance(error.config); // Renvoyer la requête d’origine
+  }
+
+  throw error;
+});
+```

--- a/posts/ja/instance.md
+++ b/posts/ja/instance.md
@@ -33,3 +33,30 @@ const instance = axios.create({
 ##### axios#put(url[, data[, config]])
 ##### axios#patch(url[, data[, config]])
 ##### axios#getUri([config])
+
+### インスタンスを設定オブジェクトで直接呼び出す
+
+`instance.get()` や `instance.post()` などの便利メソッドに加えて、Axios インスタンスは設定オブジェクトを直接渡して呼び出すこともできます。これは `axios(config)` と同様に動作し、元の設定でリクエストを再送したい場合などに便利です。
+
+```js
+const instance = axios.create({ baseURL: '/api' });
+
+// axios(config) と同じように使えます
+instance({
+  url: '/users',
+  method: 'get'
+});
+```
+
+この方法は、認証エラー時のリトライ処理などにも役立ちます。
+
+```js
+instance.interceptors.response.use(undefined, async (error) => {
+  if (error.response?.status === 401) {
+    await refreshToken();
+    return instance(error.config); // 元のリクエストを再送
+  }
+
+  throw error;
+});
+```

--- a/posts/kr/instance.md
+++ b/posts/kr/instance.md
@@ -33,3 +33,30 @@ const instance = axios.create({
 ##### axios#put(url[, data[, config]])
 ##### axios#patch(url[, data[, config]])
 ##### axios#getUri([config])
+
+### 인스턴스를 직접 config 객체로 호출하기
+
+`instance.get()`이나 `instance.post()` 같은 편의 메서드 외에도, Axios 인스턴스를 config 객체로 직접 호출할 수 있습니다. 이는 `axios(config)`와 동일하게 동작하며, 기존 설정으로 요청을 다시 보내야 할 때 유용합니다.
+
+```js
+const instance = axios.create({ baseURL: '/api' });
+
+// axios(config)와 동일하게 동작
+instance({
+  url: '/users',
+  method: 'get'
+});
+```
+
+이 방식은 인증 오류 등에서 재시도 로직을 깔끔하게 구현할 수 있습니다:
+
+```js
+instance.interceptors.response.use(undefined, async (error) => {
+  if (error.response?.status === 401) {
+    await refreshToken();
+    return instance(error.config); // 원래 요청을 다시 보냄
+  }
+
+  throw error;
+});
+```

--- a/posts/ku/instance.md
+++ b/posts/ku/instance.md
@@ -33,3 +33,30 @@ const instance = axios.create({
 ##### axios#put(url[, data[, config]])
 ##### axios#patch(url[, data[, config]])
 ##### axios#getUri([config])
+
+### بەکاربردنی نموونە بە ڕاستەوخۆییەوە بە ڕێکخستنی کۆنفێگ
+
+لەگەڵ میثۆدەکانی ئاسانەوە وەک `instance.get()` یان `instance.post()`، دەتوانیت نموونەی ئەکسیۆس بە ڕاستەوخۆییەوە بە بەکارهێنانی ئوبجێکتی ڕێکخستن بانگ بکەیت. ئەمە وەک `axios(config)` کاردەکات و بە تایبەتی کاتێک بەدوای هەمان ڕێکخستن داواکارییەک دەخەیتەوە بەسوودە.
+
+```js
+const instance = axios.create({ baseURL: '/api' });
+
+// وەک axios(config) کاردەکات
+instance({
+  url: '/users',
+  method: 'get'
+});
+```
+
+ئەم ڕێگایە ڕێکخستنێکی پاک بۆ دووبارەکردنەوەی داواکاری دابین دەکات، بۆ نموونە لە کاتی چارەسەرکردنی هەڵەی ڕوونکردنەوە:
+
+```js
+instance.interceptors.response.use(undefined, async (error) => {
+  if (error.response?.status === 401) {
+    await refreshToken();
+    return instance(error.config); // داواکارییەکە دووبارە بنێرە
+  }
+
+  throw error;
+});
+```

--- a/posts/ptBR/instance.md
+++ b/posts/ptBR/instance.md
@@ -33,3 +33,30 @@ Os métodos de instâncias disponiveis estão listadas abaixo. A configuração 
 ##### axios#put(url[, data[, config]])
 ##### axios#patch(url[, data[, config]])
 ##### axios#getUri([config])
+
+### Chamando a instância diretamente com um objeto de configuração
+
+Além dos métodos convenientes como `instance.get()` ou `instance.post()`, você também pode chamar uma instância do Axios diretamente passando um objeto de configuração. Isso funciona da mesma forma que `axios(config)` e é útil, por exemplo, para reenviar uma requisição com a configuração original.
+
+```js
+const instance = axios.create({ baseURL: '/api' });
+
+// Funciona como axios(config)
+instance({
+  url: '/users',
+  method: 'get'
+});
+```
+
+Esse padrão permite implementar uma lógica de repetição (retry) de forma limpa, como ao lidar com erros de autenticação:
+
+```js
+instance.interceptors.response.use(undefined, async (error) => {
+  if (error.response?.status === 401) {
+    await refreshToken();
+    return instance(error.config); // Reenvia a requisição original
+  }
+
+  throw error;
+});
+```

--- a/posts/ru/instance.md
+++ b/posts/ru/instance.md
@@ -33,3 +33,30 @@ const instance = axios.create({
 ##### axios#put(url[, data[, config]])
 ##### axios#patch(url[, data[, config]])
 ##### axios#getUri([config])
+
+### Вызов экземпляра напрямую с объектом конфигурации
+
+Помимо удобных методов, таких как `instance.get()` или `instance.post()`, вы можете вызывать экземпляр Axios напрямую, передавая объект конфигурации. Это работает так же, как и `axios(config)`, и особенно полезно, если нужно повторно отправить запрос с исходной конфигурацией.
+
+```js
+const instance = axios.create({ baseURL: '/api' });
+
+// Работает как axios(config)
+instance({
+  url: '/users',
+  method: 'get'
+});
+```
+
+Такой подход позволяет реализовать чистую логику повторных попыток, например, при обработке ошибок аутентификации:
+
+```js
+instance.interceptors.response.use(undefined, async (error) => {
+  if (error.response?.status === 401) {
+    await refreshToken();
+    return instance(error.config); // Повторить исходный запрос
+  }
+
+  throw error;
+});
+```

--- a/posts/tr/instance.md
+++ b/posts/tr/instance.md
@@ -33,3 +33,30 @@ Axios objesinde kullanılabilir metotlar aşağıda listelenmiştir. Belirtilen 
 ##### axios#put(url[, data[, config]])
 ##### axios#patch(url[, data[, config]])
 ##### axios#getUri([config])
+
+### Konfigürasyon Objesiyle Doğrudan Çağırma
+
+`instance.get()` veya `instance.post()` gibi yardımcı metotların yanı sıra, bir Axios örneğini doğrudan bir konfigürasyon objesiyle de çağırabilirsiniz. Bu kullanım, `axios(config)` ile aynıdır ve özellikle orijinal konfigürasyonla isteği tekrar göndermek istediğinizde faydalıdır.
+
+```js
+const instance = axios.create({ baseURL: '/api' });
+
+// axios(config) gibi çalışır
+instance({
+  url: '/users',
+  method: 'get'
+});
+```
+
+Bu yöntem, örneğin kimlik doğrulama hatalarında temiz bir tekrar deneme (retry) mantığı kurmanıza olanak tanır:
+
+```js
+instance.interceptors.response.use(undefined, async (error) => {
+  if (error.response?.status === 401) {
+    await refreshToken();
+    return instance(error.config); // Orijinal isteği tekrar gönder
+  }
+
+  throw error;
+});
+```

--- a/posts/uk/instance.md
+++ b/posts/uk/instance.md
@@ -33,3 +33,30 @@ const instance = axios.create({
 ##### axios#put(url[, data[, config]])
 ##### axios#patch(url[, data[, config]])
 ##### axios#getUri([config])
+
+### Виклик екземпляра напряму з об'єктом конфігурації
+
+Окрім зручних методів, таких як `instance.get()` чи `instance.post()`, ви можете викликати екземпляр Axios напряму, передаючи об'єкт конфігурації. Це працює так само, як і `axios(config)`, і особливо корисно, якщо потрібно повторно виконати запит з початковою конфігурацією.
+
+```js
+const instance = axios.create({ baseURL: '/api' });
+
+// Працює як axios(config)
+instance({
+  url: '/users',
+  method: 'get'
+});
+```
+
+Такий підхід дозволяє реалізувати чисту логіку повторних спроб, наприклад, при обробці помилок автентифікації:
+
+```js
+instance.interceptors.response.use(undefined, async (error) => {
+  if (error.response?.status === 401) {
+    await refreshToken();
+    return instance(error.config); // Повторити початковий запит
+  }
+
+  throw error;
+});
+```

--- a/posts/vi/instance.md
+++ b/posts/vi/instance.md
@@ -33,3 +33,30 @@ Các phương thức instance sẵn có đều được liệt kê dưới đây
 ##### axios#put(url[, data[, config]])
 ##### axios#patch(url[, data[, config]])
 ##### axios#getUri([config])
+
+### Gọi instance trực tiếp với đối tượng cấu hình
+
+Bên cạnh các phương thức tiện lợi như `instance.get()` hoặc `instance.post()`, bạn cũng có thể gọi trực tiếp một instance của Axios với một đối tượng cấu hình. Cách này tương tự như `axios(config)` và rất hữu ích khi bạn muốn gửi lại một request với cấu hình ban đầu.
+
+```js
+const instance = axios.create({ baseURL: '/api' });
+
+// Hoạt động giống như axios(config)
+instance({
+  url: '/users',
+  method: 'get'
+});
+```
+
+Cách này giúp bạn dễ dàng triển khai logic gửi lại request, ví dụ khi xử lý lỗi xác thực:
+
+```js
+instance.interceptors.response.use(undefined, async (error) => {
+  if (error.response?.status === 401) {
+    await refreshToken();
+    return instance(error.config); // Gửi lại request ban đầu
+  }
+
+  throw error;
+});
+```

--- a/posts/zh/instance.md
+++ b/posts/zh/instance.md
@@ -33,3 +33,30 @@ const instance = axios.create({
 ##### axios#put(url[, data[, config]])
 ##### axios#patch(url[, data[, config]])
 ##### axios#getUri([config])
+
+### 直接使用配置对象调用实例
+
+除了像 `instance.get()` 或 `instance.post()` 这样的便捷方法外，您还可以直接用配置对象调用 Axios 实例。这与 `axios(config)` 的用法相同，适用于需要基于原始配置重新发送请求的场景。
+
+```js
+const instance = axios.create({ baseURL: '/api' });
+
+// 类似于 axios(config)
+instance({
+  url: '/users',
+  method: 'get'
+});
+```
+
+这种方式便于实现重试逻辑，例如处理认证失败时：
+
+```js
+instance.interceptors.response.use(undefined, async (error) => {
+  if (error.response?.status === 401) {
+    await refreshToken();
+    return instance(error.config); // 重新发送原始请求
+  }
+
+  throw error;
+});
+```


### PR DESCRIPTION
Fixes #252 

### What's Added

- A new section: **"Calling the instance with a config object"** (in English and optionally translated)
- Code example showing `instance({ url, method })` usage
- Example retry pattern using `error.config` in an interceptor (commonly used in token refresh scenarios)

### Why This Matters

While this behavior is supported and commonly used, it is **not explicitly mentioned** in the instance docs. Many developers discover it only through source code or trial-and-error. Documenting it helps with:

- Discoverability of advanced usage
- Retry logic based on `error.config`
- Cleaner, DRY error handling implementations
