### PR TITLE
fix: The header module is displaying normally.

### DIFF
--- a/scss/home.scss
+++ b/scss/home.scss
@@ -14,14 +14,14 @@ body {
 header {
   position: fixed;
   padding-top: 2rem;
-  left: calc(var(--margin) / 2);
-  width: calc(100vw - var(--margin));
+  width: calc(100vw);
   display: flex;
   align-items: center;
   justify-content: space-between;
   background: #ffffffd0;
   backdrop-filter: blur(2px);
   z-index: 1;
+  padding: 0px calc(var(--margin) / 2);
 
   a.button {
     margin-right: 0 !important;


### PR DESCRIPTION
Before repair:
<img width="1613" height="507" alt="image" src="https://github.com/user-attachments/assets/b40b8787-c9c8-47f5-8dbc-4de5c8f4813e" />

After repair:
<img width="1643" height="480" alt="image" src="https://github.com/user-attachments/assets/cdb9677a-88a7-400d-8881-8326a4d8ed1c" />
