### PR TITLE
[Fixed]: fix link to node.js in intro of ja

### DIFF
--- a/posts/ja/intro.md
+++ b/posts/ja/intro.md
@@ -7,7 +7,7 @@ next_link: '/docs/example'
 
 # Axios とは?
 
-Axios は、[`Node.js`]（https://nodejs.org/）とブラウザのための *[Promise ベース](https://javascript.info/promise-basics)* の HTTP クライアントです。 これは *[Isomorphic](https://www.lullabot.com/articles/what-is-an-isomorphic-application)*（= 同じコードベースでブラウザと Node.js の両方で実行できる）と呼ばれます。 サーバー側ではネイティブ の Node.js `http` モジュールを使用し、クライアント (ブラウザ) では XMLHttpRequests を使用します。
+Axios は、[`Node.js`](https://nodejs.org/)とブラウザのための *[Promise ベース](https://javascript.info/promise-basics)* の HTTP クライアントです。 これは *[Isomorphic](https://www.lullabot.com/articles/what-is-an-isomorphic-application)*（= 同じコードベースでブラウザと Node.js の両方で実行できる）と呼ばれます。 サーバー側ではネイティブ の Node.js `http` モジュールを使用し、クライアント (ブラウザ) では XMLHttpRequests を使用します。
 
 
 # 特徴


### PR DESCRIPTION
fix link to node.js in intro of ja