### PR TITLE
[Fixed]: fix documentation page generation error

### DIFF
--- a/scripts/updateData.js
+++ b/scripts/updateData.js
@@ -223,7 +223,9 @@ const processAvatars = async (sponsorsData, avatarsPath = './assets/sponsors/ope
 
       const ext = mime.extension(headers.getContentType()) || '';
 
-      const localAvatarPath = path.join(avatarsPath, `${login || displayName}${ext ? '.' + ext : ''}`);
+      const sha = crypto.createHash('sha1')
+
+      const localAvatarPath = path.join(avatarsPath, `${sha.update(login || displayName).digest('hex')}${ext ? '.' + ext : ''}`);
 
       const sharpImage = await sharp(data)
         .trim({


### PR DESCRIPTION
Fixed an issue where build execution would fail when the opencollective username was too long.
Close #215 

The file name was changed from the username to a hash.