### PR TITLE
chore: update html-escaper from v2 to v3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "axios": "^1.11.0",
         "cheerio": "^1.1.2",
         "handlebars": "^4.7.8",
-        "html-escaper": "^2.0.2",
+        "html-escaper": "^3.0.3",
         "http-server": "^14.1.0",
         "inert-ssg": "^2.0.0-alpha.15",
         "joi": "^17.13.3",
@@ -1304,10 +1304,11 @@
       }
     },
     "node_modules/html-escaper": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
-      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
-      "dev": true
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
+      "integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/html-format": {
       "version": "1.0.1",
@@ -3978,9 +3979,9 @@
       }
     },
     "html-escaper": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
-      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
+      "integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==",
       "dev": true
     },
     "html-format": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "axios": "^1.11.0",
     "cheerio": "^1.1.2",
     "handlebars": "^4.7.8",
-    "html-escaper": "^2.0.2",
+    "html-escaper": "^3.0.3",
     "http-server": "^14.1.0",
     "inert-ssg": "^2.0.0-alpha.15",
     "joi": "^17.13.3",


### PR DESCRIPTION
update html-escaper from v2 to v3
- <https://github.com/WebReflection/html-escaper/commits/master/>
- Confirmed that `npm run build` works without any problems
- Confirmed that the return value of `renderTooltip` in `updateData.js` is the same before and after the update