### PR TITLE
[Fixed] Italian localization prefix overwrote English

### DIFF
--- a/inert.config.js
+++ b/inert.config.js
@@ -150,8 +150,7 @@ const langs = [
   {
     dir: "ltr",
     name: "Italiano",
-    prefix: "/",
-    postsDir: "/it/",
+    prefix: "/it/",
     config: itConfig,
   },
 ];

--- a/it.lang.js
+++ b/it.lang.js
@@ -5,7 +5,7 @@
 module.exports = {
   // Language display name. MUST BE THE SAME AS IN [inert.config.js].custom.langs
   display: "Italiano",
-  prefix: "/",
+  prefix: "/it/",
   dir: "ltr",
   lang: "it",
   // `p` stands for `paragraph`. This will contain translations of full text blocks


### PR DESCRIPTION
## Summary

Fixes #307

PR #306 added Italian with `prefix: "/"`, which overwrote English. English is now inaccessible and missing from the language picker.

## Cause

```javascript
{
  dir: "ltr",
  name: "Italiano",
  prefix: "/",        // should be "/it/"
  postsDir: "/it/",
  config: itConfig,
},
```

## Changes

- `inert.config.js`: Italian prefix `"/"` → `"/it/"`, removed redundant `postsDir`
- `it.lang.js`: prefix `"/"` → `"/it/"`

## Result

- English at `/`
- Italian at `/it/`
- Both in language picker

## Deploy Preview

- English: https://deploy-preview-308--axios-docs.netlify.app/docs/intro
- Italian: https://deploy-preview-308--axios-docs.netlify.app/it/docs/intro