### PR TITLE
Add a link to Axios ecosystem

### DIFF
--- a/en.lang.js
+++ b/en.lang.js
@@ -123,6 +123,11 @@ module.exports = {
     },
     {
       type: "link",
+      href: "https://github.com/axios/axios/blob/v1.x/ECOSYSTEM.md",
+      text: "Ecosystem",
+    },
+    {
+      type: "link",
       href: "/docs/notes",
       text: "Notes",
     },


### PR DESCRIPTION
This adds a separate link to the ecosystem instead of being buried in Notes