### PR TITLE
[Removed] Remove duplicated AbortController signal for Axios cancellation

### DIFF
--- a/posts/en/req_config.md
+++ b/posts/en/req_config.md
@@ -218,9 +218,6 @@ These are the available config options for making requests. Only the `url` is re
   cancelToken: new CancelToken(function (cancel) {
   }),
 
-  // an alternative way to cancel Axios requests using AbortController
-  signal: new AbortController().signal,
-
   // `decompress` indicates whether or not the response body should be decompressed 
   // automatically. If set to `true` will also remove the 'content-encoding' header 
   // from the responses objects of all decompressed responses


### PR DESCRIPTION
Removed the alternative cancellation method using AbortController.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the AbortController signal example from the Axios request config docs to avoid duplication and confusion; cancellation is documented with cancelToken only.

<sup>Written for commit fa0501275ff4d7f6e23b2fc9cf2c6840ca445628. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

