### PR TITLE
[Fixed] Correct Chinese translation in request config documentation

### DIFF
--- a/posts/zh/req_config.md
+++ b/posts/zh/req_config.md
@@ -104,7 +104,6 @@ next_link: '/zh/docs/res_schema'
 
   // `responseEncoding` 表示用于解码响应的编码 (Node.js 专属)
   // 注意：忽略 `responseType` 的值为 'stream'，或者是客户端请求
-  // Note: Ignored for `responseType` of 'stream' or client-side requests
   responseEncoding: 'utf8', // 默认值
 
   // `xsrfCookieName` 是 xsrf token 的值，被用作 cookie 的名称
@@ -171,14 +170,13 @@ next_link: '/zh/docs/res_schema'
     }
   },
 
-  // see https://axios-http.com/zh/docs/cancellation
+  // 参见 https://axios-http.com/zh/docs/cancellation
   cancelToken: new CancelToken(function (cancel) {
   }),
 
-  // `decompress` indicates whether or not the response body should be decompressed 
-  // automatically. If set to `true` will also remove the 'content-encoding' header 
-  // from the responses objects of all decompressed responses
-  // - Node only (XHR cannot turn off decompression)
+  //`decompress` 定义了是否应自动解压缩响应体。
+  // 如果设置为 `true`，还会从所有已解压缩响应的响应对象中移除 `content-encoding` 标头。
+  // - 仅限 Node，(XHR 无法关闭解压缩)
   decompress: true // 默认值
 
 }


### PR DESCRIPTION
## Summary
This PR fixes translation inconsistencies in the Chinese version of the request config documentation (`posts/zh/req_config.md`).

## Changes
-  Removed duplicate English comment line in `responseEncoding` field
-  Added complete Chinese translation for `decompress` option
-  Translated `cancelToken` reference comment to Chinese format

## Checklist
- I have read the [contributing guidelines](https://github.com/axios/axios-docs/blob/master/CONTRIBUTING.md)
- I have verified the changes locally with `inert build` (if applicable)
- I have not modified any filenames, only content

## Related
N/A (or link to issue if exists)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrected Chinese translation in the request config docs to improve clarity and consistency for zh readers.

- **Bug Fixes**
  - Removed duplicate English comment for responseEncoding.
  - Added Chinese translation for the decompress option, including Node-only note.
  - Translated cancelToken reference comment to Chinese (参见 https://axios-http.com/zh/docs/cancellation).

<sup>Written for commit 2ded4486a5ea0e1624da89b9424300163fa102e4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

