### PR TITLE
docs: update AbortSignal.timeout() compatibility note to include modern browsers

### DIFF
--- a/posts/en/cancellation.md
+++ b/posts/en/cancellation.md
@@ -34,7 +34,7 @@ axios.get('/foo/bar', {
 controller.abort()
 ```
 
-Example with a timeout using latest [`AbortSignal.timeout()`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal/timeout) API [nodejs 17.3+]:
+Example with a timeout using latest [`AbortSignal.timeout()`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal/timeout) API (Node.js 17.3+ and all modern browsers):
 ```js
 axios.get('/foo/bar', {
    signal: AbortSignal.timeout(5000) //Aborts request after 5 seconds


### PR DESCRIPTION
## What this PR does
Updates the AbortSignal.timeout() compatibility note in the Cancellation docs.

## Why this change is needed
The current docs label AbortSignal.timeout() as [nodejs 17.3+] only, which is
misleading. This API is now supported in all modern browsers:
- Chrome 103+
- Firefox 100+
- Safari 16+

## Changes made
- Updated the compatibility note in posts/en/cancellation.md

## Reference
https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal/timeout_static

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies AbortSignal.timeout() support in the Cancellation docs: available in Node.js 17.3+ and all modern browsers (Chrome 103+, Firefox 100+, Safari 16+). Replaces the previous "Node.js only" note.

<sup>Written for commit b63e65f9459ac0dbdbf02243955b3e40b3ed34c1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

