### PR TITLE
Change "upgrade guide" to "migration guide"

### DIFF
--- a/posts/ar/notes.md
+++ b/posts/ar/notes.md
@@ -24,7 +24,7 @@ axios.get('/user?ID=12345');
 ## الموارد
 
 * [سجل التغييرات](https://github.com/axios/axios/blob/v1.x/CHANGELOG.md)
-* [دليل الترقية](https://github.com/axios/axios/blob/v1.x/UPGRADE_GUIDE.md)
+* [دليل الترحيل](https://github.com/axios/axios/blob/v1.x/MIGRATION_GUIDE.md)
 * [النظام البيئي](https://github.com/axios/axios/blob/v1.x/ECOSYSTEM.md)
 * [دليل المساهمة](https://github.com/axios/axios/blob/v1.x/CONTRIBUTING.md)
 * [مدونة قواعد السلوك](https://github.com/axios/axios/blob/v1.x/CODE_OF_CONDUCT.md)

--- a/posts/de/notes.md
+++ b/posts/de/notes.md
@@ -23,7 +23,7 @@ axios.get('/user?ID=12345');
 ## Ressourcen
 
 * [Changelog](https://github.com/axios/axios/blob/v1.x/CHANGELOG.md)
-* [Upgrade Guide](https://github.com/axios/axios/blob/v1.x/UPGRADE_GUIDE.md)
+* [Migration Guide](https://github.com/axios/axios/blob/v1.x/MIGRATION_GUIDE.md)
 * [Ecosystem](https://github.com/axios/axios/blob/v1.x/ECOSYSTEM.md)
 * [Contributing Guide](https://github.com/axios/axios/blob/v1.x/CONTRIBUTING.md)
 * [Code of Conduct](https://github.com/axios/axios/blob/v1.x/CODE_OF_CONDUCT.md)

--- a/posts/en/notes.md
+++ b/posts/en/notes.md
@@ -20,7 +20,7 @@ axios.get('/user?ID=12345');
 ## Resources
 
 * [Changelog](https://github.com/axios/axios/blob/v1.x/CHANGELOG.md)
-* [Upgrade Guide](https://github.com/axios/axios/blob/v1.x/UPGRADE_GUIDE.md)
+* [Migration Guide](https://github.com/axios/axios/blob/v1.x/MIGRATION_GUIDE.md)
 * [Ecosystem](https://github.com/axios/axios/blob/v1.x/ECOSYSTEM.md)
 * [Contributing Guide](https://github.com/axios/axios/blob/v1.x/CONTRIBUTING.md)
 * [Code of Conduct](https://github.com/axios/axios/blob/v1.x/CODE_OF_CONDUCT.md)

--- a/posts/es/notes.md
+++ b/posts/es/notes.md
@@ -26,7 +26,7 @@ axios.get("/user?ID=12345");
 ## Recursos
 
 - [Cambios](https://github.com/axios/axios/blob/v1.x/CHANGELOG.md)
-- [Guía de Actualización](https://github.com/axios/axios/blob/v1.x/UPGRADE_GUIDE.md)
+- [Guía de Migración](https://github.com/axios/axios/blob/v1.x/MIGRATION_GUIDE.md)
 - [Ecosistema](https://github.com/axios/axios/blob/v1.x/ECOSYSTEM.md)
 - [Guía de Contribución](https://github.com/axios/axios/blob/v1.x/CONTRIBUTING.md)
 - [Códido de Conducta](https://github.com/axios/axios/blob/v1.x/CODE_OF_CONDUCT.md)

--- a/posts/fa/notes.md
+++ b/posts/fa/notes.md
@@ -24,7 +24,7 @@ axios.get('/user?ID=12345');
 ## منابع
 
 * [تغییرات](https://github.com/axios/axios/blob/v1.x/CHANGELOG.md)
-* [راهنمای ارتقاء](https://github.com/axios/axios/blob/v1.x/UPGRADE_GUIDE.md)
+* [راهنمای مهاجرت](https://github.com/axios/axios/blob/v1.x/MIGRATION_GUIDE.md)
 * [زیست بوم](https://github.com/axios/axios/blob/v1.x/ECOSYSTEM.md)
 * [راهنمای مشارکت برنامه نویسان](https://github.com/axios/axios/blob/v1.x/CONTRIBUTING.md)
 * [قوانین رفتاری](https://github.com/axios/axios/blob/v1.x/CODE_OF_CONDUCT.md)

--- a/posts/fr/notes.md
+++ b/posts/fr/notes.md
@@ -24,7 +24,7 @@ axios.get('/user?ID=12345');
 ## Ressources
 
 * [Changelog](https://github.com/axios/axios/blob/v1.x/CHANGELOG.md)
-* [Guide de mise à niveau](https://github.com/axios/axios/blob/v1.x/UPGRADE_GUIDE.md)
+* [Guide de migration](https://github.com/axios/axios/blob/v1.x/MIGRATION_GUIDE.md)
 * [Écosystème](https://github.com/axios/axios/blob/v1.x/ECOSYSTEM.md)
 * [Contribuer à Axios](https://github.com/axios/axios/blob/v1.x/CONTRIBUTING.md)
 * [Code de conduite](https://github.com/axios/axios/blob/v1.x/CODE_OF_CONDUCT.md)

--- a/posts/hi/notes.md
+++ b/posts/hi/notes.md
@@ -25,7 +25,7 @@ axios.get('/user?ID=12345');
 ## संसाधन
 
 * [चेंजलॉग](https://github.com/axios/axios/blob/v1.x/CHANGELOG.md)
-* [अपग्रेड गाइड](https://github.com/axios/axios/blob/v1.x/UPGRADE_GUIDE.md)
+* [माइग्रेशन गाइड](https://github.com/axios/axios/blob/v1.x/MIGRATION_GUIDE.md)
 * [इकोसिस्टम](https://github.com/axios/axios/blob/v1.x/ECOSYSTEM.md)
 * [योगदान गाइड](https://github.com/axios/axios/blob/v1.x/CONTRIBUTING.md)
 * [आचार संहिता](https://github.com/axios/axios/blob/v1.x/CODE_OF_CONDUCT.md)

--- a/posts/it/notes.md
+++ b/posts/it/notes.md
@@ -26,7 +26,7 @@ axios.get("/user?ID=12345");
 ## Risorse
 
 - [Changelog](https://github.com/axios/axios/blob/v1.x/CHANGELOG.md)
-- [Come Aggiornare](https://github.com/axios/axios/blob/v1.x/UPGRADE_GUIDE.md)
+- [Come Migrare](https://github.com/axios/axios/blob/v1.x/MIGRATION_GUIDE.md)
 - [Ecosistema](https://github.com/axios/axios/blob/v1.x/ECOSYSTEM.md)
 - [Come Contribuire](https://github.com/axios/axios/blob/v1.x/CONTRIBUTING.md)
 - [Codice di Condotta](https://github.com/axios/axios/blob/v1.x/CODE_OF_CONDUCT.md)

--- a/posts/ja/notes.md
+++ b/posts/ja/notes.md
@@ -26,7 +26,7 @@ axios.get('/user?ID=12345');
 ## リソース
 
 * [変更履歴](https://github.com/axios/axios/blob/v1.x/CHANGELOG.md)
-* [アップグレード ガイド](https://github.com/axios/axios/blob/v1.x/UPGRADE_GUIDE.md)
+* [移行ガイド](https://github.com/axios/axios/blob/v1.x/MIGRATION_GUIDE.md)
 * [エコシステム](https://github.com/axios/axios/blob/v1.x/ECOSYSTEM.md)
 * [コントリビューター ガイド](https://github.com/axios/axios/blob/v1.x/CONTRIBUTING.md)
 * [行動規範](https://github.com/axios/axios/blob/v1.x/CODE_OF_CONDUCT.md)

--- a/posts/kr/notes.md
+++ b/posts/kr/notes.md
@@ -25,7 +25,7 @@ axios.get('/user?ID=12345');
 ## 리소스
 
 * [변경 로그](https://github.com/axios/axios/blob/v1.x/CHANGELOG.md)
-* [업그레이드 가이드](https://github.com/axios/axios/blob/v1.x/UPGRADE_GUIDE.md)
+* [마이그레이션 가이드](https://github.com/axios/axios/blob/v1.x/MIGRATION_GUIDE.md)
 * [에코시스템](https://github.com/axios/axios/blob/v1.x/ECOSYSTEM.md)
 * [기여 가이드](https://github.com/axios/axios/blob/v1.x/CONTRIBUTING.md)
 * [행동 지침](https://github.com/axios/axios/blob/v1.x/CODE_OF_CONDUCT.md)

--- a/posts/ku/notes.md
+++ b/posts/ku/notes.md
@@ -26,7 +26,7 @@ axios.get('/user?ID=12345');
 ## سەرچاوەکان
 
 * تۆماری گۆڕانکارییەکان - [Changelog](https://github.com/axios/axios/blob/v1.x/CHANGELOG.md)
-* ڕێبەریی بەرزکردنەوە - [Upgrade Guide](https://github.com/axios/axios/blob/v1.x/UPGRADE_GUIDE.md)
+* ڕێنمایی گواستنەوە - [Migration Guide](https://github.com/axios/axios/blob/v1.x/MIGRATION_GUIDE.md)
 * ژینگە سیستەم - [Ecosystem](https://github.com/axios/axios/blob/v1.x/ECOSYSTEM.md)
 * ڕێبەریی بەژداریکردن - [Contributing Guide](https://github.com/axios/axios/blob/v1.x/CONTRIBUTING.md)
 * کۆدی ڕەفتارکردن - [Code of Conduct](https://github.com/axios/axios/blob/v1.x/CODE_OF_CONDUCT.md)

--- a/posts/ptBR/notes.md
+++ b/posts/ptBR/notes.md
@@ -24,7 +24,7 @@ axios.get('/user?ID=12345');
 ## Recursos
 
 * [Changelog](https://github.com/axios/axios/blob/v1.x/CHANGELOG.md)
-* [Guia de upgrade](https://github.com/axios/axios/blob/v1.x/UPGRADE_GUIDE.md)
+* [Guia de Migração](https://github.com/axios/axios/blob/v1.x/MIGRATION_GUIDE.md)
 * [Ecossistema](https://github.com/axios/axios/blob/v1.x/ECOSYSTEM.md)
 * [Guia de contribuição](https://github.com/axios/axios/blob/v1.x/CONTRIBUTING.md)
 * [Código de contuda](https://github.com/axios/axios/blob/v1.x/CODE_OF_CONDUCT.md)

--- a/posts/ru/notes.md
+++ b/posts/ru/notes.md
@@ -24,7 +24,7 @@ axios.get('/user?ID=12345');
 ## Ресурсы
 
 * [Список изменений](https://github.com/axios/axios/blob/v1.x/CHANGELOG.md)
-* [Руководство по обновлению](https://github.com/axios/axios/blob/v1.x/UPGRADE_GUIDE.md)
+* [Руководство по миграции](https://github.com/axios/axios/blob/v1.x/MIGRATION_GUIDE.md)
 * [Экосистема](https://github.com/axios/axios/blob/v1.x/ECOSYSTEM.md)
 * [Пособие для соавторов](https://github.com/axios/axios/blob/v1.x/CONTRIBUTING.md)
 * [Code of Conduct](https://github.com/axios/axios/blob/v1.x/CODE_OF_CONDUCT.md)

--- a/posts/tr/notes.md
+++ b/posts/tr/notes.md
@@ -24,7 +24,7 @@ axios.get('/user?ID=12345');
 ## Kaynaklar
 
 * [Changelog](https://github.com/axios/axios/blob/v1.x/CHANGELOG.md)
-* [Upgrade Guide](https://github.com/axios/axios/blob/v1.x/UPGRADE_GUIDE.md)
+* [Migration Guide](https://github.com/axios/axios/blob/v1.x/MIGRATION_GUIDE.md)
 * [Ecosystem](https://github.com/axios/axios/blob/v1.x/ECOSYSTEM.md)
 * [Contributing Guide](https://github.com/axios/axios/blob/v1.x/CONTRIBUTING.md)
 * [Code of Conduct](https://github.com/axios/axios/blob/v1.x/CODE_OF_CONDUCT.md)

--- a/posts/uk/notes.md
+++ b/posts/uk/notes.md
@@ -25,7 +25,7 @@ axios.get('/user?ID=12345');
 ## Resources
 
 * [Changelog](https://github.com/axios/axios/blob/v1.x/CHANGELOG.md)
-* [Посібник з оновлення](https://github.com/axios/axios/blob/v1.x/UPGRADE_GUIDE.md)
+* [Посібник з міграції](https://github.com/axios/axios/blob/v1.x/MIGRATION_GUIDE.md)
 * [Екосистема](https://github.com/axios/axios/blob/v1.x/ECOSYSTEM.md)
 * [Посібник для співавторів](https://github.com/axios/axios/blob/v1.x/CONTRIBUTING.md)
 * [Code of Conduct](https://github.com/axios/axios/blob/v1.x/CODE_OF_CONDUCT.md)

--- a/posts/vi/notes.md
+++ b/posts/vi/notes.md
@@ -24,7 +24,7 @@ axios.get('/user?ID=12345');
 ## Tài nguyên
 
 * [Changelog](https://github.com/axios/axios/blob/v1.x/CHANGELOG.md)
-* [Hướng dẫn nâng cấp](https://github.com/axios/axios/blob/v1.x/UPGRADE_GUIDE.md)
+* [Hướng dẫn chuyển đổi](https://github.com/axios/axios/blob/v1.x/MIGRATION_GUIDE.md)
 * [Hệ sinh thái](https://github.com/axios/axios/blob/v1.x/ECOSYSTEM.md)
 * [Hướng dẫn đóng góp](https://github.com/axios/axios/blob/v1.x/CONTRIBUTING.md)
 * [Quy tắc ứng xử](https://github.com/axios/axios/blob/v1.x/CODE_OF_CONDUCT.md)

--- a/posts/zh/notes.md
+++ b/posts/zh/notes.md
@@ -23,7 +23,7 @@ axios.get('/user?ID=12345');
 ## 资源
 
 * [变更日志](https://github.com/axios/axios/blob/v1.x/CHANGELOG.md)
-* [升级指南](https://github.com/axios/axios/blob/v1.x/UPGRADE_GUIDE.md)
+* [迁移指南](https://github.com/axios/axios/blob/v1.x/MIGRATION_GUIDE.md)
 * [生态系统](https://github.com/axios/axios/blob/v1.x/ECOSYSTEM.md)
 * [贡献指南](https://github.com/axios/axios/blob/v1.x/CONTRIBUTING.md)
 * [行为准则](https://github.com/axios/axios/blob/v1.x/CODE_OF_CONDUCT.md)

--- a/posts/zhTW/notes.md
+++ b/posts/zhTW/notes.md
@@ -22,7 +22,7 @@ axios.get('/user?ID=12345');
 ## 其他資源
 
 * [變更日誌](https://github.com/axios/axios/blob/v1.x/CHANGELOG.md)
-* [升級指南](https://github.com/axios/axios/blob/v1.x/UPGRADE_GUIDE.md)
+* [遷移指南](https://github.com/axios/axios/blob/v1.x/MIGRATION_GUIDE.md)
 * [生態系](https://github.com/axios/axios/blob/v1.x/ECOSYSTEM.md)
 * [貢獻指南](https://github.com/axios/axios/blob/v1.x/CONTRIBUTING.md)
 * [行為準則](https://github.com/axios/axios/blob/v1.x/CODE_OF_CONDUCT.md)


### PR DESCRIPTION
- Fix broken links to `UPGRADE_GUIDE.md`, which was renamed to `MIGRATION_GUIDE.md`.
  → see axios/axios#5170

- Update all translations accordingly.
  → Translations were generated using an LLM with context-aware terminology (“software migration” instead of “human migration”) to ensure accuracy and consistency.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace all “Upgrade Guide” references with “Migration Guide” and fix broken links after `UPGRADE_GUIDE.md` was renamed to `MIGRATION_GUIDE.md` across all locales. Updated translations to use correct software “migration” terminology.

<sup>Written for commit e4778f73eeb592c46f318d7f0c032ae809a8a6bd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

